### PR TITLE
Implement global whitelist in regex banner

### DIFF
--- a/banjax.go
+++ b/banjax.go
@@ -212,6 +212,8 @@ func main() {
 		banner,
 		&rateLimitMutex,
 		&ipToRegexStates,
+		&decisionListsMutex,
+		&decisionLists,
 		&wg,
 	)
 

--- a/banjax_integration_test.go
+++ b/banjax_integration_test.go
@@ -323,4 +323,15 @@ func TestRegexesWithRates(t *testing.T) {
 		// should be banned (nginx_block = 403)
 		{"GET", prefix + "/45in60", 403, ClientIP("11.11.11.11"), nil},
 	})
+
+	// test target 3, make 45 req
+	httpStress(
+		[]TestResource{{"GET", prefix + "/45in60-whitelist", 200, ClientIP("12.12.12.12"), nil}},
+		45)
+
+	time.Sleep(2 * time.Second)
+	httpTester(t, []TestResource{
+		// should not be banned due to global whitelist
+		{"GET", prefix + "/45in60-whitelist", 200, ClientIP("12.12.12.12"), nil},
+	})
 }

--- a/fixtures/banjax-config-test-regex-banner.yaml
+++ b/fixtures/banjax-config-test-regex-banner.yaml
@@ -2,6 +2,7 @@ config_version: 2022-01-02_00:00:00
 global_decision_lists:
   allow:
     - 20.20.20.20
+    - 12.12.12.12  # test whitelist working in regex
   iptables_block:
     - 30.40.50.60
   nginx_block:

--- a/internal/regex_rate_limiter.go
+++ b/internal/regex_rate_limiter.go
@@ -140,9 +140,12 @@ func consumeLine(
 	decisionListsMutex.Unlock()
 	foundInIpFilter := false
 	// not found with direct match, try to match if contain within CIDR subnet
-	if !ok && (*decisionLists).GlobalDecisionListsIPFilter[Allow].Allowed(timeIpRest[1]) {
-		// log.Printf("matched in ipfilter %v %s", Allow, timeIpRest[1])
-		foundInIpFilter = true
+	_, globalIpfilterOk := (*decisionLists).GlobalDecisionListsIPFilter[Allow]
+	if !ok && globalIpfilterOk {
+		if (*decisionLists).GlobalDecisionListsIPFilter[Allow].Allowed(timeIpRest[1]) {
+			// log.Printf("matched in ipfilter %v %s", Allow, timeIpRest[1])
+			foundInIpFilter = true
+		}
 	}
 	if (ok && decision == Allow) || foundInIpFilter {
 		// log.Printf("matched in global decision list %v %s, exit regex banner", Allow, timeIpRest[1])


### PR DESCRIPTION
Implement global whitelist in regex banner to prevent "fake" banning regex log

Since regex banner works like a sidecar, it issue a ban when it tails nginx log and finds a match that should be banned, but the ban will only be executed if the user comes again and go through the regular banjax decision making process.

This PR adds a global whitelist in front of the regex banner to prevent this from happening.