### PR TITLE
Fix data races and refactor shared state

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -25,7 +25,7 @@ exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
 # Watch these directories if you specified.
 include_dir = []
 # Watch these files.
-include_file = []
+include_file = ["banjax-config.yaml"]
 # Exclude files.
 exclude_file = []
 # Exclude specific regular expressions.

--- a/.air.toml
+++ b/.air.toml
@@ -9,7 +9,7 @@ tmp_dir = "tmp"
 # Array of commands to run before each build
 pre_cmd = []
 # Just plain old shell command. You could use `make` as well.
-cmd = "go build -o ./banjax ."
+cmd = "go build -buildvcs=false -o ./banjax ."
 # Array of commands to run after ^C
 post_cmd = []
 # Binary file yields from `cmd`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-FROM golang:1.22.6-bookworm
+FROM golang:1.23.6-bookworm
 
 RUN set -x \
  && DEBIAN_FRONTEND=noninteractive apt-get update \
@@ -25,13 +25,14 @@ COPY ./banjax-config.yaml /etc/banjax/
 
 RUN mkdir -p /var/log/banjax
 
+# Support live reload with air. To enable it, define ENABLE_AIR=1 env variable when running the
+# container.
+COPY ./.air.toml /opt/banjax/
+RUN mkdir -p /opt/banjax/tmp
+RUN go install github.com/air-verse/air@latest
+
 EXPOSE 8081
 
 WORKDIR /opt/banjax
 
-# To enable live reload for dev, uncomment the following lines
-# COPY ./.air.toml /opt/banjax/
-# RUN go install github.com/air-verse/air@latest
-# RUN mkdir -p /opt/banjax/tmp
-# CMD ["air", "-c", ".air.toml"]
-CMD ["./banjax"]
+CMD ["./entrypoint.sh"]

--- a/banjax-config.yaml
+++ b/banjax-config.yaml
@@ -60,6 +60,7 @@ regexes_with_rates:
     hosts_to_skip:
       example.com: true
       foo.bar: true
+      localhost: true
   - decision: challenge
     hits_per_interval: 45
     interval: 60
@@ -70,6 +71,8 @@ regexes_with_rates:
     interval: 10
     regex: "^GET .*"
     rule: "All sites/GET on root: 22 req/10 sec"
+    hosts_to_skip:
+      localhost: true
   - decision: allow
     hits_per_interval: 0
     interval: 1

--- a/banjax.go
+++ b/banjax.go
@@ -166,7 +166,8 @@ func main() {
 	config := internal.Config{}
 	load_config(&config, standaloneTestingPtr, configFilenamePtr, restartTime, debugPtr)
 
-	rateLimitStates := internal.NewRateLimitStates()
+	regexStates := internal.NewRegexRateLimitStates()
+	failedChallengeStates := internal.NewFailedChallengeRateLimitStates()
 	passwordProtectedPaths := internal.PasswordProtectedPaths{}
 
 	staticDecisionLists, err := internal.NewStaticDecisionListsFromConfig(&config)
@@ -255,7 +256,8 @@ func main() {
 		staticDecisionLists,
 		dynamicDecisionLists,
 		&passwordProtectedPaths,
-		rateLimitStates,
+		regexStates,
+		failedChallengeStates,
 		banner,
 		&wg,
 	)
@@ -265,7 +267,7 @@ func main() {
 		&config,
 		banner,
 		staticDecisionLists,
-		rateLimitStates,
+		regexStates,
 		&wg,
 	)
 
@@ -292,7 +294,8 @@ func main() {
 		29*time.Second,
 		&config,
 		dynamicDecisionLists,
-		rateLimitStates,
+		regexStates,
+		failedChallengeStates,
 	)
 
 	if !config.DisableKafka {
@@ -314,7 +317,8 @@ func reportMetrics(
 	interval time.Duration,
 	config *internal.Config,
 	decisionLists *internal.DynamicDecisionLists,
-	rateLimitStates *internal.RateLimitStates,
+	regexStates *internal.RegexRateLimitStates,
+	failedChallengeStates *internal.FailedChallengeRateLimitStates,
 ) {
 	logFileName := ""
 	if config.StandaloneTesting {
@@ -341,7 +345,8 @@ func reportMetrics(
 		internal.WriteMetricsToEncoder(
 			logEncoder,
 			decisionLists,
-			rateLimitStates,
+			regexStates,
+			failedChallengeStates,
 		)
 	}
 }

--- a/banjax.go
+++ b/banjax.go
@@ -14,7 +14,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"regexp"
 	"sync"
 	"syscall"
 	"time"
@@ -92,23 +91,8 @@ func load_config(config *internal.Config, standaloneTestingPtr *bool, configFile
 		config.PasswordPageBytes = passwordPageBytes
 	}
 
-	for i := range config.RegexesWithRates {
-		re, err := regexp.Compile(config.RegexesWithRates[i].Regex)
-		if err != nil {
-			panic("bad regex")
-		}
-		config.RegexesWithRates[i].CompiledRegex = *re
-	}
-
-	for site, p_regex := range config.PerSiteRegexWithRates {
+	for site, _ := range config.PerSiteRegexWithRates {
 		log.Printf("PerSiteRegexWithRates: %s\n", site)
-		for i := range p_regex {
-			re, err := regexp.Compile(config.PerSiteRegexWithRates[site][i].Regex)
-			if err != nil {
-				panic("bad regex")
-			}
-			config.PerSiteRegexWithRates[site][i].CompiledRegex = *re
-		}
 	}
 
 	if config.Debug {

--- a/banjax_base_test.go
+++ b/banjax_base_test.go
@@ -99,21 +99,24 @@ func httpTester(t *testing.T, resources []TestResource) {
 
 func httpCheck(client *http.Client, resource_ptr *TestResource, t *testing.T) {
 	resource := *resource_ptr
-	resp := httpRequest(client, resource)
+	resp := httpRequest(client, resource, t)
 
 	assert.Equal(t, resource.response_code, resp.StatusCode, "Response code is not correct")
 
 	if len(resource.contains) > 0 {
 		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Fatal("Error when ready Body from ", resource.method, resource.name)
-		}
+		assert.Nil(t, err, "Error when ready Body from ", resource.method, resource.name)
 		resp.Body.Close()
 		for _, lookup := range resource.contains {
-			if !strings.Contains(string(body), lookup) {
-				log.Fatalf("Expected string [[ %s ]] not found when testing: %s %s",
-					lookup, resource.method, resource.name)
-			}
+			assert.Containsf(
+				t,
+				string(body),
+				lookup,
+				"Expected string [[ %s ]] not found when testing: %s %s",
+				lookup,
+				resource.method,
+				resource.name,
+			)
 		}
 	}
 }
@@ -130,7 +133,7 @@ func httpTesterWithCookie(t *testing.T, resources []TestResource) {
 			if len(resource.contains) > 1 {
 				log.Print(cookies[resource.contains[0]])
 				expectedMaxAge, _ := strconv.Atoi(resource.contains[1])
-				assert.Equal(t, cookies[resource.contains[0]].MaxAge, expectedMaxAge)
+				assert.Equal(t, expectedMaxAge, cookies[resource.contains[0]].MaxAge)
 			}
 		})
 	}
@@ -138,7 +141,7 @@ func httpTesterWithCookie(t *testing.T, resources []TestResource) {
 
 func httpCheckWithCookie(client *http.Client, resource_ptr *TestResource, t *testing.T) (cookieMap CookieMap) {
 	resource := *resource_ptr
-	resp := httpRequest(client, resource)
+	resp := httpRequest(client, resource, t)
 
 	assert.Equal(t, resource.response_code, resp.StatusCode, "Response code is not correct")
 
@@ -152,12 +155,12 @@ func httpCheckWithCookie(client *http.Client, resource_ptr *TestResource, t *tes
 	return
 }
 
-func httpStress(resources []TestResource, repeat int) {
+func httpStress(resources []TestResource, repeat int, t *testing.T) {
 	var resp *http.Response
 	client := http.Client{}
 	for _, resource := range resources {
 		for i := 0; i <= repeat; i++ {
-			resp = httpRequest(&client, resource)
+			resp = httpRequest(&client, resource, t)
 			if resp != nil && resp.Body != nil {
 				resp.Body.Close()
 			}
@@ -165,21 +168,17 @@ func httpStress(resources []TestResource, repeat int) {
 	}
 }
 
-func httpRequest(client *http.Client, resource TestResource) *http.Response {
+func httpRequest(client *http.Client, resource TestResource, t *testing.T) *http.Response {
 	req, err := http.NewRequest(resource.method, endpoint+resource.name, nil)
-	if err != nil {
-		log.Fatal("Error when creating the request object",
-			resource.method, resource.name)
-	}
+	assert.Nil(t, err, "Error when creating the request object", resource.method, resource.name)
+
 	for key, values := range resource.headers {
 		for _, value := range values {
 			req.Header.Set(key, value)
 		}
 	}
 	resp, err := client.Do(req)
-	if err != nil {
-		log.Fatal("Error when doing the request ", resource.method, resource.name, err)
-	}
+	assert.Nil(t, err, "Error when doing the request ", resource.method, resource.name, err)
 
 	if req != nil && req.Body != nil {
 		req.Body.Close()
@@ -204,18 +203,23 @@ func randomIP() string {
 	return strings.Join(octets, ".")
 }
 
-func reloadConfig(path string, randomReqCount int) {
+func reloadConfig(path string, randomReqCount int, t *testing.T) {
 	done := make(chan bool)
 
 	// just to make a mark in log so we know when the reload is done
 	httpStress(
-		[]TestResource{{"GET", "/auth_request?path=/reloadConfig", 200, randomXClientIP(), nil}}, 1)
+		[]TestResource{{"GET", "/auth_request?path=/reloadConfig", 200, randomXClientIP(), nil}},
+		1,
+		t,
+	)
 
 	// Simulate activity of http requests when the config is reloaded
 	go func() {
 		httpStress(
 			[]TestResource{{"GET", "/auth_request?path=/", 200, randomXClientIP(), nil}},
-			randomReqCount)
+			randomReqCount,
+			t,
+		)
 		done <- true
 	}()
 

--- a/banjax_base_test.go
+++ b/banjax_base_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -43,7 +42,7 @@ func tearDown() {
 }
 
 func createTempDir() {
-	dir, err := ioutil.TempDir("", "banjax-tests")
+	dir, err := os.MkdirTemp("", "banjax-tests")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/banjax_integration_test.go
+++ b/banjax_integration_test.go
@@ -3,12 +3,19 @@
 package main
 
 import (
+	"io"
+	"log"
 	"os"
 	"testing"
 	"time"
 )
 
 func TestMain(m *testing.M) {
+	// Suppress log output to reduce noise.
+	logWriter := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(logWriter)
+
 	setUp()
 	exit_code := m.Run()
 	tearDown()

--- a/banjax_integration_test.go
+++ b/banjax_integration_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPathWithChallengeCookies(t *testing.T) {
-	defer reloadConfig(fixtureConfigTest, 1)
+	defer reloadConfig(fixtureConfigTest, 1, t)
 
 	prefix := "/auth_request?path="
 	httpTesterWithCookie(t, []TestResource{
@@ -33,14 +33,14 @@ func TestPathWithChallengeCookies(t *testing.T) {
 	})
 
 	// reload without per site max age, test if default value 14400 present
-	reloadConfig(fixtureConfigTestReloadCIDR, 1)
+	reloadConfig(fixtureConfigTestReloadCIDR, 1, t)
 	httpTesterWithCookie(t, []TestResource{
 		{"GET", prefix + "/wp-admin", 401, nil, []string{"deflect_password3", "14400"}}, // testing max-age
 	})
 }
 
 func TestGlobalPerSiteDecisionListsMask(t *testing.T) {
-	defer reloadConfig(fixtureConfigTest, 1)
+	defer reloadConfig(fixtureConfigTest, 1, t)
 
 	prefix := "/auth_request?path="
 	httpTester(t, []TestResource{
@@ -55,7 +55,7 @@ func TestGlobalPerSiteDecisionListsMask(t *testing.T) {
 		{"GET", prefix + "/per_site_mask_128_ban", 429, ClientIP("192.168.0.128"), nil},
 	})
 
-	reloadConfig(fixtureConfigTestReloadCIDR, 1)
+	reloadConfig(fixtureConfigTestReloadCIDR, 1, t)
 	httpTester(t, []TestResource{
 		{"GET", "/info", 200, nil, []string{"2022-03-02"}},
 		{"GET", prefix + "/global_mask_64_nginx_block", 403, ClientIP("192.168.2.64"), nil},
@@ -101,7 +101,7 @@ func TestBanjaxEndpoint(t *testing.T) {
 }
 
 func TestProtectedResources(t *testing.T) {
-	defer reloadConfig(fixtureConfigTest, 50)
+	defer reloadConfig(fixtureConfigTest, 50, t)
 
 	/*
 		password_protected_paths:
@@ -145,7 +145,7 @@ func TestProtectedResources(t *testing.T) {
 			"localhost":
 				- wp-admin
 	*/
-	reloadConfig(fixtureConfigTestReload, 50)
+	reloadConfig(fixtureConfigTestReload, 50, t)
 	httpTester(t, []TestResource{
 		{"GET", "/info", 200, nil, []string{"2022-02-03"}},
 		// protected resources
@@ -154,7 +154,7 @@ func TestProtectedResources(t *testing.T) {
 }
 
 func TestGlobalDecisionLists(t *testing.T) {
-	defer reloadConfig(fixtureConfigTest, 50)
+	defer reloadConfig(fixtureConfigTest, 50, t)
 
 	/*
 		global_decision_lists:
@@ -184,7 +184,7 @@ func TestGlobalDecisionLists(t *testing.T) {
 			challenge:
 				- 20.20.20.20  # test value change
 	*/
-	reloadConfig(fixtureConfigTestReload, 50)
+	reloadConfig(fixtureConfigTestReload, 50, t)
 	httpTester(t, []TestResource{
 		{"GET", "/info", 200, nil, []string{"2022-02-03"}},
 		// global_decision_lists
@@ -194,7 +194,7 @@ func TestGlobalDecisionLists(t *testing.T) {
 }
 
 func TestPerSiteDecisionLists(t *testing.T) {
-	defer reloadConfig(fixtureConfigTest, 50)
+	defer reloadConfig(fixtureConfigTest, 50, t)
 
 	/*
 		per_site_decision_lists:
@@ -222,7 +222,7 @@ func TestPerSiteDecisionLists(t *testing.T) {
 				block:
 				- 92.92.92.92
 	*/
-	reloadConfig(fixtureConfigTestReload, 50)
+	reloadConfig(fixtureConfigTestReload, 50, t)
 	httpTester(t, []TestResource{
 		{"GET", "/info", 200, nil, []string{"2022-02-03"}},
 		// per_site_decision_lists
@@ -230,7 +230,7 @@ func TestPerSiteDecisionLists(t *testing.T) {
 	})
 
 	// test if return 403 after too many failed password page, after it should see 401 immediately
-	reloadConfig(fixtureConfigTestPersiteFail, 1)
+	reloadConfig(fixtureConfigTestPersiteFail, 1, t)
 	httpTester(t, []TestResource{
 		{"GET", "/info", 200, nil, []string{"2023-08-23"}},
 		{"GET", prefix + "/wp-admin", 401, ClientIP("92.92.92.92"), nil},
@@ -251,7 +251,7 @@ func TestPerSiteDecisionLists(t *testing.T) {
 }
 
 func TestSitewideShaInvList(t *testing.T) {
-	defer reloadConfig(fixtureConfigTest, 50)
+	defer reloadConfig(fixtureConfigTest, 50, t)
 
 	/*
 		sitewide_sha_inv_list:
@@ -270,7 +270,7 @@ func TestSitewideShaInvList(t *testing.T) {
 			foobar.com: no_block
 			"localhost:8081": block
 	*/
-	reloadConfig(fixtureConfigTestShaInv, 50)
+	reloadConfig(fixtureConfigTestShaInv, 50, t)
 	httpTester(t, []TestResource{
 		{"GET", "/info", 200, nil, []string{"2022-02-03"}},
 		// sitewide_sha_inv_list on
@@ -282,7 +282,7 @@ func TestSitewideShaInvList(t *testing.T) {
 			example.com: block
 			foobar.com: no_block
 	*/
-	reloadConfig(fixtureConfigTest, 50)
+	reloadConfig(fixtureConfigTest, 50, t)
 	httpTester(t, []TestResource{
 		{"GET", "/info", 200, nil, []string{"2022-01-02"}},
 		// sitewide_sha_inv_list off
@@ -291,7 +291,7 @@ func TestSitewideShaInvList(t *testing.T) {
 }
 
 func TestRegexesWithRatesChallengeme(t *testing.T) {
-	defer reloadConfig(fixtureConfigTestRegexBanner, 1) // prepare for next test
+	defer reloadConfig(fixtureConfigTestRegexBanner, 1, t) // prepare for next test
 
 	/*
 		- decision: challenge
@@ -315,7 +315,7 @@ func TestRegexesWithRatesChallengeme(t *testing.T) {
 	/*
 		removed
 	*/
-	reloadConfig(fixtureConfigTestReload, 1)
+	reloadConfig(fixtureConfigTestReload, 1, t)
 	httpTester(t, []TestResource{
 		{"GET", "/info", 200, nil, []string{"2022-02-03"}},
 		// regexes_with_rates (rule removed)
@@ -325,7 +325,7 @@ func TestRegexesWithRatesChallengeme(t *testing.T) {
 }
 
 func TestRegexesWithRates(t *testing.T) {
-	defer reloadConfig(fixtureConfigTest, 1)
+	defer reloadConfig(fixtureConfigTest, 1, t)
 
 	/* (fixtureConfigTestRegexBanner)
 	# test target 1
@@ -360,7 +360,9 @@ func TestRegexesWithRates(t *testing.T) {
 	// test target 2, make 45 req
 	httpStress(
 		[]TestResource{{"GET", prefix + "/45in60", 200, ClientIP("11.11.11.11"), nil}},
-		45)
+		45,
+		t,
+	)
 
 	time.Sleep(2 * time.Second)
 	httpTester(t, []TestResource{
@@ -371,7 +373,9 @@ func TestRegexesWithRates(t *testing.T) {
 	// test target 3, make 45 req
 	httpStress(
 		[]TestResource{{"GET", prefix + "/45in60-whitelist", 200, ClientIP("12.12.12.12"), nil}},
-		45)
+		45,
+		t,
+	)
 
 	time.Sleep(2 * time.Second)
 	httpTester(t, []TestResource{
@@ -381,7 +385,7 @@ func TestRegexesWithRates(t *testing.T) {
 }
 
 func TestRegexesWithRatesAllowList(t *testing.T) {
-	defer reloadConfig(fixtureConfigTest, 1)
+	defer reloadConfig(fixtureConfigTest, 1, t)
 
 	prefix := "/auth_request?path="
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./logs/banjax:/var/log/banjax/
       - .:/opt/banjax/
     restart: on-failure:5
+    env_file: ".env"
 
   nginx:
     build:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -n "$ENABLE_AIR" ]; then
+    air -c .air.toml
+else
+    ./banjax
+fi
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 if [ -n "$ENABLE_AIR" ]; then
-    air -c .air.toml
+    exec air -c .air.toml
 else
-    ./banjax
+    exec ./banjax
 fi
-

--- a/internal/config.go
+++ b/internal/config.go
@@ -59,6 +59,8 @@ type Config struct {
 	ReloadTime                             int
 	Hostname                               string
 	HmacSecret                             string              `yaml:"hmac_secret"`
+	// Path to the file to write gin (http server) log to. Use "-" to log to the stdout or empty
+	// string to disable logging.
 	GinLogFile                             string              `yaml:"gin_log_file"`
 	SitewideShaInvList                     map[string]string   `yaml:"sitewide_sha_inv_list"`
 	MetricsLogFileName                     string              `yaml:"metrics_log_file"`

--- a/internal/config.go
+++ b/internal/config.go
@@ -224,10 +224,12 @@ type MetricsLogLine struct {
 func WriteMetricsToEncoder(
 	metricsLogEncoder *json.Encoder,
 	decisionLists *DynamicDecisionLists,
-	rateLimitStates *RateLimitStates,
+	regexStates *RegexRateLimitStates,
+	failedChallengeStates *FailedChallengeRateLimitStates,
 ) {
 	lenExpiringChallenges, lenExpiringBlocks := decisionLists.Metrics()
-	lenRegexStates, lenFailedChallengeStates := rateLimitStates.Metrics()
+	lenRegexStates := regexStates.Len()
+	lenFailedChallengeStates := failedChallengeStates.Len()
 
 	metricsLogLine := MetricsLogLine{
 		Time:                     time.Now().Format(time.RFC1123),

--- a/internal/config.go
+++ b/internal/config.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/jeremy5189/ipfilter-no-iploc/v2"
 )
 
 type Config struct {
@@ -60,20 +58,20 @@ type Config struct {
 	RestartTime                            int
 	ReloadTime                             int
 	Hostname                               string
-	HmacSecret                             string            `yaml:"hmac_secret"`
-	GinLogFile                             string            `yaml:"gin_log_file"`
-	SitewideShaInvList                     map[string]string `yaml:"sitewide_sha_inv_list"`
-	MetricsLogFileName                     string            `yaml:"metrics_log_file"`
-	ShaInvChallengeHTML                    string            `yaml:"sha_inv_challenge_html"`
-	PasswordProtectedPathHTML              string            `yaml:"password_protected_path_html"`
-	Debug                                  bool              `yaml:"debug"`
-	DisableLogging                         map[string]bool   `yaml:"disable_logging"`
-	BanningLogFileTemp                     string            `yaml:"banning_log_file_temp"`
-	DisableKafka                           bool              `yaml:"disable_kafka"`
-	SessionCookieHmacSecret                string            `yaml:"session_cookie_hmac_secret"`
-	SessionCookieTtlSeconds                int               `yaml:"session_cookie_ttl_seconds"`
-	SessionCookieNotVerify                 bool              `yaml:"session_cookie_not_verify"`
-	SitesToDisableBaskerville              map[string]bool   `yaml:"sites_to_disable_baskerville"`
+	HmacSecret                             string              `yaml:"hmac_secret"`
+	GinLogFile                             string              `yaml:"gin_log_file"`
+	SitewideShaInvList                     map[string]string   `yaml:"sitewide_sha_inv_list"`
+	MetricsLogFileName                     string              `yaml:"metrics_log_file"`
+	ShaInvChallengeHTML                    string              `yaml:"sha_inv_challenge_html"`
+	PasswordProtectedPathHTML              string              `yaml:"password_protected_path_html"`
+	Debug                                  bool                `yaml:"debug"`
+	DisableLogging                         map[string]bool     `yaml:"disable_logging"`
+	BanningLogFileTemp                     string              `yaml:"banning_log_file_temp"`
+	DisableKafka                           bool                `yaml:"disable_kafka"`
+	SessionCookieHmacSecret                string              `yaml:"session_cookie_hmac_secret"`
+	SessionCookieTtlSeconds                int                 `yaml:"session_cookie_ttl_seconds"`
+	SessionCookieNotVerify                 bool                `yaml:"session_cookie_not_verify"`
+	SitesToDisableBaskerville              map[string]bool     `yaml:"sites_to_disable_baskerville"`
 	SitesToShaInvPathExceptions            map[string][]string `yaml:"sha_inv_path_exceptions"`
 }
 
@@ -87,71 +85,6 @@ type RegexWithRate struct {
 	HostsToSkip     map[string]bool `yaml:"hosts_to_skip"`
 }
 
-// XXX previously i had a DefaultAllow as the first enum, which fell through
-// my case statements and into the default: switch elsewhere. scary bug.
-// maybe use _ as first enum? but then remember to use it in the string conversion
-// functions just below x_x
-type Decision int
-
-const (
-	Allow         = iota
-	Challenge     = iota
-	NginxBlock    = iota
-	IptablesBlock = iota
-)
-
-type ExpiringDecision struct {
-	Decision        Decision
-	Expires         time.Time
-	IpAddress       string
-	fromBaskerville bool
-	domain          string
-}
-
-// XXX is this really how you make an enum in go?
-type FailAction int
-
-const (
-	Block   = iota
-	NoBlock = iota
-)
-
-func (d Decision) String() string {
-	return [...]string{"Allow", "Challenge", "NginxBlock", "IptablesBlock"}[d]
-}
-
-// XXX if a string in the config file isn't one of these Decision tokens,
-// this map will default to returning the zero value (or something like that,
-// think about this another time)
-var stringToDecision = map[string]Decision{
-	"allow":          Allow,
-	"challenge":      Challenge,
-	"nginx_block":    NginxBlock,
-	"iptables_block": IptablesBlock,
-}
-
-type StringToDecision map[string]Decision
-type StringToExpiringDecision map[string]ExpiringDecision
-type StringToStringToDecision map[string]StringToDecision
-type StringToFailAction map[string]FailAction
-type DecisionToIPFilter map[Decision]*ipfilter.IPFilter
-type StringToDecisionToIPFilter map[string]DecisionToIPFilter
-
-type DecisionLists struct {
-	// static blocklists, allowlists, challengelists populated from the config file
-	GlobalDecisionLists  StringToDecision         // ip -> Decision
-	PerSiteDecisionLists StringToStringToDecision // site -> ip -> Decision
-	// dynamic lists populated from the regex rate limits + kafka
-	ExpiringDecisionLists StringToExpiringDecision // ip -> ExpiringDecision
-	// dynamic lists populated from the kafka, like ExpiringDecisionLists but session ID as index
-	ExpiringDecisionListsSessionId StringToExpiringDecision
-	// static site-wide lists (legacy banjax_sha_inv and user_banjax_sha_inv)
-	// XXX someday need sha-inv *and* captcha
-	// XXX could be merged with PerSiteDecisionLists if we matched on ip ranges
-	SitewideShaInvList           StringToFailAction // site -> Challenge (block after many failures or don't)
-	GlobalDecisionListsIPFilter  DecisionToIPFilter
-	PerSiteDecisionListsIPFilter StringToDecisionToIPFilter
-}
 
 type StringToBool map[string]bool
 type StringToStringToBool map[string]StringToBool
@@ -228,87 +161,6 @@ func ConfigToPasswordProtectedPaths(config *Config) PasswordProtectedPaths {
 	}
 }
 
-func ConfigToDecisionLists(config *Config) DecisionLists {
-	perSiteDecisionLists := make(StringToStringToDecision)
-	globalDecisionLists := make(StringToDecision)
-	expiringDecisionLists := make(StringToExpiringDecision)
-	expiringDecisionListsSessionId := make(StringToExpiringDecision)
-	sitewideShaInvList := make(StringToFailAction)
-	globalDecisionListsIPFilter := make(DecisionToIPFilter)
-	perSiteDecisionListsIPFilter := make(StringToDecisionToIPFilter)
-
-	for site, decisionToIps := range config.PerSiteDecisionLists {
-		for decisionString, ips := range decisionToIps {
-			decision := stringToDecision[decisionString]
-			for _, ip := range ips {
-				_, ok := perSiteDecisionLists[site]
-				if !ok {
-					perSiteDecisionLists[site] = make(StringToDecision)
-					perSiteDecisionListsIPFilter[site] = make(DecisionToIPFilter)
-				}
-				if !strings.Contains(ip, "/") {
-					perSiteDecisionLists[site][ip] = decision
-					if config.Debug {
-						log.Printf("site: %s, decision: %s, ip: %s\n", site, decisionString, ip)
-					}
-				} else {
-					if config.Debug {
-						log.Printf("per-site decision: %s, CIDR: %s, put in IPFilter\n", decisionString, ip)
-					}
-				}
-			}
-			if len(ips) > 0 {
-				// only init ipfilter if there is IP
-				// or there might be panic: assignment to entry in nil map
-				perSiteDecisionListsIPFilter[site][decision] = ipfilter.New(ipfilter.Options{
-					AllowedIPs:     ips,
-					BlockByDefault: true,
-				})
-			}
-		}
-	}
-
-	for decisionString, ips := range config.GlobalDecisionLists {
-		decision := stringToDecision[decisionString]
-		for _, ip := range ips {
-			if !strings.Contains(ip, "/") {
-				globalDecisionLists[ip] = decision
-				if config.Debug {
-					log.Printf("global decision: %s, ip: %s\n", decisionString, ip)
-				}
-			} else {
-				if config.Debug {
-					log.Printf("global decision: %s, CIDR: %s, put in IPFilter\n", decisionString, ip)
-				}
-			}
-		}
-		globalDecisionListsIPFilter[decision] = ipfilter.New(ipfilter.Options{
-			AllowedIPs:     ips,
-			BlockByDefault: true,
-		})
-	}
-
-	for site, failAction := range config.SitewideShaInvList {
-		if config.Debug {
-			log.Printf("sitewide site: %s, failAction: %s\n", site, failAction)
-		}
-		if failAction == "block" {
-			sitewideShaInvList[site] = Block
-		} else if failAction == "no_block" {
-			sitewideShaInvList[site] = NoBlock
-		} else {
-			panic("!!! sitewide_sha_inv_list action is block or no_block")
-		}
-	}
-
-	// log.Printf("per-site decisions: %v\n", perSiteDecisionLists)
-	// log.Printf("global decisions: %v\n", globalDecisionLists)
-	return DecisionLists{
-		globalDecisionLists, perSiteDecisionLists,
-		expiringDecisionLists, expiringDecisionListsSessionId, sitewideShaInvList,
-		globalDecisionListsIPFilter, perSiteDecisionListsIPFilter}
-}
-
 // XXX use string.Builder
 func (ipToRegexStates IpToRegexStates) String() string {
 	buf := bytes.Buffer{}
@@ -323,55 +175,6 @@ func (ipToRegexStates IpToRegexStates) String() string {
 			buf.WriteString(fmt.Sprintf("%v", *state))
 			buf.WriteString("\n")
 		}
-		buf.WriteString("\n")
-	}
-	return buf.String()
-}
-
-// XXX use string.Builder
-func (perSiteDecisionLists StringToStringToDecision) String() string {
-	buf := bytes.Buffer{}
-	for host, ipsToDecisions := range perSiteDecisionLists {
-		buf.WriteString(fmt.Sprintf("%v", host))
-		buf.WriteString(":\n")
-		for ip, decision := range ipsToDecisions {
-			buf.WriteString("\t")
-			buf.WriteString(fmt.Sprintf("%v", ip))
-			buf.WriteString(":\n")
-			buf.WriteString("\t\t")
-			buf.WriteString(fmt.Sprintf("%v", decision.String()))
-			buf.WriteString("\n")
-		}
-	}
-	return buf.String()
-}
-
-// XXX use string.Builder
-func (globalDecisionLists StringToDecision) String() string {
-	buf := bytes.Buffer{}
-	for ip, decision := range globalDecisionLists {
-		buf.WriteString(fmt.Sprintf("%v", ip))
-		buf.WriteString(":\n")
-		buf.WriteString("\t")
-		buf.WriteString(fmt.Sprintf("%v", decision.String()))
-		buf.WriteString("\n")
-	}
-	return buf.String()
-}
-
-// XXX use string.Builder
-func (expiringDecisionLists StringToExpiringDecision) String() string {
-	buf := bytes.Buffer{}
-	for ip, expiringDecision := range expiringDecisionLists {
-		buf.WriteString(fmt.Sprintf("%v", ip))
-		buf.WriteString(":\n")
-		buf.WriteString("\t")
-		buf.WriteString(fmt.Sprintf("%v %v until %v (baskerville: %v)",
-			expiringDecision.domain,
-			expiringDecision.Decision.String(),
-			expiringDecision.Expires.Format("15:04:05"),
-			expiringDecision.fromBaskerville,
-		))
 		buf.WriteString("\n")
 	}
 	return buf.String()
@@ -420,127 +223,6 @@ func (bannedEntry BannedEntry) String() string {
 	)
 }
 
-func checkExpiringDecisionListsByDomain(domain string, decisionLists *DecisionLists) []BannedEntry {
-	// interate (*decisionLists).ExpiringDecisionLists
-	// if domain matches, append to []ExpiringDecision
-	// return []BannedEntry
-	var bannedEntries []BannedEntry
-	for ip, expiringDecision := range (*decisionLists).ExpiringDecisionLists {
-		if expiringDecision.domain == domain && expiringDecision.Decision >= Challenge {
-			bannedEntries = append(bannedEntries, BannedEntry{
-				IpOrSessionId:   ip,
-				domain:          expiringDecision.domain,
-				Decision:        expiringDecision.Decision.String(), // Convert Decision to string
-				Expires:         expiringDecision.Expires,
-				FromBaskerville: expiringDecision.fromBaskerville,
-			})
-		}
-	}
-	for sessionId, expiringDecision := range (*decisionLists).ExpiringDecisionListsSessionId {
-		if expiringDecision.domain == domain && expiringDecision.Decision >= Challenge {
-			bannedEntries = append(bannedEntries, BannedEntry{
-				IpOrSessionId:   sessionId,
-				domain:          expiringDecision.domain,
-				Decision:        expiringDecision.Decision.String(), // Convert Decision to string
-				Expires:         expiringDecision.Expires,
-				FromBaskerville: expiringDecision.fromBaskerville,
-			})
-		}
-	}
-	return bannedEntries
-}
-
-// XXX mmm could hold the lock for a while?
-func RemoveExpiredDecisions(
-	decisionListsMutex *sync.Mutex,
-	decisionLists *DecisionLists,
-) {
-	decisionListsMutex.Lock()
-	defer decisionListsMutex.Unlock()
-
-	for ip, expiringDecision := range (*decisionLists).ExpiringDecisionLists {
-		if time.Now().Sub(expiringDecision.Expires) > 0 {
-			delete((*decisionLists).ExpiringDecisionLists, ip)
-			// log.Println("deleted expired decision from expiring lists")
-		}
-	}
-}
-
-func removeExpiredDecisionsByIp(
-	decisionListsMutex *sync.Mutex,
-	decisionLists *DecisionLists,
-	ip string,
-) {
-	decisionListsMutex.Lock()
-	defer decisionListsMutex.Unlock()
-
-	delete((*decisionLists).ExpiringDecisionLists, ip)
-	// log.Printf("deleted IP %v from expiring lists", ip)
-}
-
-func updateExpiringDecisionLists(
-	config *Config,
-	ip string,
-	decisionListsMutex *sync.Mutex,
-	decisionLists *DecisionLists,
-	expires time.Time,
-	newDecision Decision,
-	fromBaskerville bool,
-	domain string,
-) {
-	decisionListsMutex.Lock()
-	defer decisionListsMutex.Unlock()
-
-	existingExpiringDecision, ok := (*decisionLists).ExpiringDecisionLists[ip]
-	if ok {
-		if newDecision <= existingExpiringDecision.Decision {
-			if config.Debug {
-				log.Println("updateExpiringDecisionLists: not with less serious", existingExpiringDecision.Decision, newDecision, ip, domain)
-			}
-			return
-		}
-	}
-	if config.Debug {
-		log.Println("updateExpiringDecisionLists: update with existing and new: ", existingExpiringDecision.Decision, newDecision, ip, domain)
-		// log.Println("From baskerville", fromBaskerville)
-	}
-
-	// XXX We are not using nginx to banjax cache feature yet
-	// purgeNginxAuthCacheForIp(ip)
-	(*decisionLists).ExpiringDecisionLists[ip] = ExpiringDecision{
-		newDecision, expires, ip, fromBaskerville, domain}
-}
-
-func updateExpiringDecisionListsSessionId(
-	config *Config,
-	ip string,
-	sessionId string,
-	decisionListsMutex *sync.Mutex,
-	decisionLists *DecisionLists,
-	expires time.Time,
-	newDecision Decision,
-	fromBaskerville bool,
-	domain string,
-) {
-	decisionListsMutex.Lock()
-	defer decisionListsMutex.Unlock()
-
-	existingExpiringDecision, ok := (*decisionLists).ExpiringDecisionListsSessionId[sessionId]
-	if ok {
-		if newDecision <= existingExpiringDecision.Decision {
-			return
-		}
-	}
-
-	if config.Debug {
-		log.Printf("updateExpiringDecisionListsSessionId: Update session id decision with IP %s, session id %s, existing and new: %v, %v\n",
-			ip, sessionId, existingExpiringDecision.Decision, newDecision)
-	}
-
-	(*decisionLists).ExpiringDecisionListsSessionId[sessionId] = ExpiringDecision{
-		newDecision, expires, ip, fromBaskerville, domain}
-}
-
 type MetricsLogLine struct {
 	Time                     string
 	LenExpiringChallenges    int
@@ -551,25 +233,12 @@ type MetricsLogLine struct {
 
 func WriteMetricsToEncoder(
 	metricsLogEncoder *json.Encoder,
-	decisionListsMutex *sync.Mutex,
-	decisionLists *DecisionLists,
+	decisionLists *DynamicDecisionLists,
 	rateLimitMutex *sync.Mutex,
 	ipToRegexStates *IpToRegexStates,
 	failedChallengeStates *FailedChallengeStates,
 ) {
-	decisionListsMutex.Lock()
-	defer decisionListsMutex.Unlock()
-
-	lenExpiringChallenges := 0
-	lenExpiringBlocks := 0
-
-	for _, expiringDecision := range (*decisionLists).ExpiringDecisionLists {
-		if expiringDecision.Decision == Challenge {
-			lenExpiringChallenges += 1
-		} else if (expiringDecision.Decision == NginxBlock) || (expiringDecision.Decision == IptablesBlock) {
-			lenExpiringBlocks += 1
-		}
-	}
+	lenExpiringChallenges, lenExpiringBlocks := decisionLists.Metrics()
 
 	metricsLogLine := MetricsLogLine{
 		Time:                     time.Now().Format(time.RFC1123),

--- a/internal/config.go
+++ b/internal/config.go
@@ -76,13 +76,46 @@ type Config struct {
 }
 
 type RegexWithRate struct {
-	Rule            string `yaml:"rule"`
-	Regex           string `yaml:"regex"`
-	CompiledRegex   regexp.Regexp
-	Interval        float64         `yaml:"interval"`
-	HitsPerInterval int             `yaml:"hits_per_interval"`
-	Decision        string          `yaml:"decision"`
-	HostsToSkip     map[string]bool `yaml:"hosts_to_skip"`
+	Rule            string
+	Regex           regexp.Regexp
+	Interval        float64
+	HitsPerInterval int
+	Decision        Decision
+	HostsToSkip     map[string]bool
+}
+
+func (r *RegexWithRate) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var i struct {
+		Rule            string 			`yaml:"rule"`
+		Regex           string    	 	`yaml:"regex"`
+		Interval        float64         `yaml:"interval"`
+		HitsPerInterval int             `yaml:"hits_per_interval"`
+		Decision        string          `yaml:"decision"`
+		HostsToSkip     map[string]bool `yaml:"hosts_to_skip"`
+	}
+
+	if err := unmarshal(&i); err != nil {
+		return err
+	}
+
+	regex, err := regexp.Compile(i.Regex)
+    if err != nil {
+		return err
+    }
+
+    decision, err := ParseDecision(i.Decision)
+    if err != nil {
+		return err
+    }
+
+	r.Rule 				= i.Rule
+	r.Regex 			= *regex
+	r.Interval 		  	= i.Interval
+	r.HitsPerInterval 	= i.HitsPerInterval
+	r.Decision          = decision
+	r.HostsToSkip       = i.HostsToSkip
+
+	return nil
 }
 
 

--- a/internal/config_holder.go
+++ b/internal/config_holder.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2025, eQualit.ie inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package internal
+
+import (
+	_ "embed"
+	"fmt"
+	"log"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+//go:embed sha-inverse-challenge.html
+var shaInvChallengeEmbed []byte
+
+//go:embed password-protected-path.html
+var passProtPathEmbed []byte
+
+// Thread-safe holder for config which supports hot-reloading.
+type ConfigHolder struct {
+	config atomic.Pointer[Config]
+}
+
+func NewConfigHolder(path string, standaloneTesting bool, debug bool) (*ConfigHolder, error) {
+	holder := &ConfigHolder{
+		config: atomic.Pointer[Config]{},
+	}
+
+	restartTime := int(time.Now().Unix())
+	config, err := load(path, restartTime, standaloneTesting, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	holder.config.Store(config)
+
+	return holder, nil
+}
+
+// Get pointer to the latest read-only snapshot of the config.
+func (h *ConfigHolder) Get() *Config {
+	return h.config.Load()
+}
+
+// Reload config from a file at the given path.
+func (h *ConfigHolder) Reload(path string) error {
+	old := h.config.Load()
+	new, err := load(path, old.RestartTime, old.StandaloneTesting, old.Debug)
+
+	if err != nil {
+		return err
+	}
+
+	h.config.Store(new)
+
+	return nil
+}
+
+func load(path string, restartTime int, standaloneTesting bool, debug bool) (*Config, error) {
+	config := &Config{
+		RestartTime: restartTime,
+	}
+
+	config.ReloadTime = int(time.Now().Unix()) // XXX
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Println("couldn't get hostname! using dummy")
+		hostname = "unknown-hostname"
+	}
+	config.Hostname = hostname
+	log.Printf("INIT: hostname: %s", hostname)
+
+	configBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file at %v: %w", path, err)
+	}
+	// log.Printf("read %v\n", string(configBytes[:]))
+
+	config.StandaloneTesting = standaloneTesting
+	err = yaml.Unmarshal(configBytes, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	// boolean default = false
+	if config.Debug {
+		log.Printf("read config %v\n", *config)
+	}
+
+	if config.ShaInvChallengeHTML != "" {
+		log.Printf("INIT: Reading SHA-inverse challenge HTML from %s", config.ShaInvChallengeHTML)
+		challengerBytes, err := os.ReadFile(config.ShaInvChallengeHTML)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't read sha-inverse-challenge.html: %w", err)
+		}
+		config.ChallengerBytes = challengerBytes
+	} else {
+		log.Printf("INIT: Reading SHA-inverse challenge HTML from embed")
+		config.ChallengerBytes = shaInvChallengeEmbed
+	}
+
+	if config.PasswordProtectedPathHTML != "" {
+		log.Printf("INIT: Reading Password protected path HTML from %s", config.PasswordProtectedPathHTML)
+		passwordPageBytes, err := os.ReadFile(config.PasswordProtectedPathHTML)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't read password-protected-path.html: %w", err)
+		}
+		config.PasswordPageBytes = passwordPageBytes
+	} else {
+		log.Printf("INIT: Reading Password protected path HTML from embed")
+		config.PasswordPageBytes = passProtPathEmbed
+	}
+
+	for site := range config.PerSiteRegexWithRates {
+		log.Printf("PerSiteRegexWithRates: %s\n", site)
+	}
+
+	if config.Debug {
+		for site, failAction := range config.SitewideShaInvList {
+			log.Printf("load_config: sitewide site: %s, failAction: %s\n", site, failAction)
+		}
+	}
+
+	if !config.Debug && debug {
+		log.Printf("debug mode enabled by command line param")
+		config.Debug = true
+	}
+
+	if config.StandaloneTesting {
+		config.DisableKafka = true
+
+		log.Println("!!! setting ServerLogFile to testing-log-file.txt")
+		config.ServerLogFile = "testing-log-file.txt"
+		config.BanningLogFile = "banning-log-file.txt"
+	}
+
+	if config.ServerLogFile == "" {
+		return nil, fmt.Errorf("config needs server_log_file")
+	}
+
+	if config.IptablesBanSeconds == 0 {
+		return nil, fmt.Errorf("config needs iptables_ban_seconds")
+	}
+
+	if len(config.KafkaBrokers) < 1 {
+		return nil, fmt.Errorf("config needs kafka_brokers")
+	}
+	log.Println("INIT: Kafka brokers: ", config.KafkaBrokers)
+
+	return config, nil
+}
+

--- a/internal/config_holder.go
+++ b/internal/config_holder.go
@@ -26,11 +26,13 @@ var passProtPathEmbed []byte
 // Thread-safe holder for config which supports hot-reloading.
 type ConfigHolder struct {
 	config atomic.Pointer[Config]
+	path   string
 }
 
 func NewConfigHolder(path string, standaloneTesting bool, debug bool) (*ConfigHolder, error) {
 	holder := &ConfigHolder{
 		config: atomic.Pointer[Config]{},
+		path:   path,
 	}
 
 	restartTime := int(time.Now().Unix())
@@ -49,10 +51,10 @@ func (h *ConfigHolder) Get() *Config {
 	return h.config.Load()
 }
 
-// Reload config from a file at the given path.
-func (h *ConfigHolder) Reload(path string) error {
+// Reload config.
+func (h *ConfigHolder) Reload() error {
 	old := h.config.Load()
-	new, err := load(path, old.RestartTime, old.StandaloneTesting, old.Debug)
+	new, err := load(h.path, old.RestartTime, old.StandaloneTesting, old.Debug)
 
 	if err != nil {
 		return err
@@ -157,4 +159,3 @@ func load(path string, restartTime int, standaloneTesting bool, debug bool) (*Co
 
 	return config, nil
 }
-

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -10,9 +10,10 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
-	"gopkg.in/yaml.v2"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 )
 
 const passwordProtectedConfString = `
@@ -63,6 +64,7 @@ rule: "All sites/methods: 800 req/30 sec"
 hosts_to_skip:
   localhost: true
 `
+
 func TestRegexWithRate(t *testing.T) {
 	var r RegexWithRate
 	err := yaml.Unmarshal([]byte(regexWithRateString), &r)
@@ -71,12 +73,12 @@ func TestRegexWithRate(t *testing.T) {
 	}
 
 	assert.Equal(t, NginxBlock, r.Decision)
-  assert.Equal(t, 800, r.HitsPerInterval)
-  assert.Equal(t, 30.0, r.Interval)
-  assert.Equal(t, ".*", r.Regex.String())
-  assert.Equal(t, "All sites/methods: 800 req/30 sec", r.Rule)
-  assert.Equal(t, 1, len(r.HostsToSkip))
-  assert.Equal(t, true, r.HostsToSkip["localhost"])
+	assert.Equal(t, 800, r.HitsPerInterval)
+	assert.Equal(t, 30 * time.Second, r.Interval)
+	assert.Equal(t, ".*", r.Regex.String())
+	assert.Equal(t, "All sites/methods: 800 req/30 sec", r.Rule)
+	assert.Equal(t, 1, len(r.HostsToSkip))
+	assert.Equal(t, true, r.HostsToSkip["localhost"])
 }
 
 func loadConfigString(configStr string) *Config {

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -74,7 +74,7 @@ func TestRegexWithRate(t *testing.T) {
 
 	assert.Equal(t, NginxBlock, r.Decision)
 	assert.Equal(t, 800, r.HitsPerInterval)
-	assert.Equal(t, 30 * time.Second, r.Interval)
+	assert.Equal(t, 30*time.Second, r.Interval)
 	assert.Equal(t, ".*", r.Regex.String())
 	assert.Equal(t, "All sites/methods: 800 req/30 sec", r.Rule)
 	assert.Equal(t, 1, len(r.HostsToSkip))

--- a/internal/decision.go
+++ b/internal/decision.go
@@ -89,7 +89,7 @@ type StaticDecisionLists struct {
 	content atomic.Pointer[staticDecisionLists]
 }
 
-func NewStaticDecisionListsFromConfig(config *Config) (*StaticDecisionLists, error) {
+func NewStaticDecisionLists(config *Config) (*StaticDecisionLists, error) {
 	content, err := newStaticDecisionListsFromConfig(config)
 	if err != nil {
 		return nil, err

--- a/internal/decision.go
+++ b/internal/decision.go
@@ -1,0 +1,586 @@
+// Copyright (c) 2025, eQualit.ie inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package internal
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jeremy5189/ipfilter-no-iploc/v2"
+)
+
+type Decision int
+
+const (
+	_ Decision = iota
+	Allow
+	Challenge
+	NginxBlock
+	IptablesBlock
+)
+
+func ParseDecision(s string) (Decision, error) {
+	switch s {
+	case "allow":
+		return Allow, nil
+	case "challenge":
+		return Challenge, nil
+	case "nginx_block":
+		return NginxBlock, nil
+	case "iptables_block":
+		return IptablesBlock, nil
+	default:
+		return 0, fmt.Errorf("invalid decision: %v", s)
+	}
+}
+
+func (d Decision) String() string {
+	switch d {
+	case Allow:
+		return "Allow"
+	case Challenge:
+		return "Challenge"
+	case NginxBlock:
+		return "NginxBlock"
+	case IptablesBlock:
+		return "IptablesBlock"
+	default:
+		return ""
+	}
+}
+
+type ExpiringDecision struct {
+	Decision        Decision
+	Expires         time.Time
+	IpAddress       string
+	fromBaskerville bool
+	domain          string
+}
+
+type FailAction int
+
+const (
+	_ FailAction = iota
+	Block
+	NoBlock
+)
+
+func ParseFailAction(s string) (FailAction, error) {
+	switch s {
+	case "block":
+		return Block, nil
+	case "no_block":
+		return NoBlock, nil
+	default:
+		return 0, fmt.Errorf("invalid fail action: %v", s)
+	}
+}
+
+// Decision lists that don't change until the program is restarted or the config is hot-reloaded.
+type StaticDecisionLists struct {
+	value staticDecisionLists
+	mutex sync.Mutex
+}
+
+func NewStaticDecisionListsFromConfig(config *Config) (*StaticDecisionLists, error) {
+	value, err := newStaticDecisionListsFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	lists := &StaticDecisionLists{
+		value: value,
+		mutex: sync.Mutex{},
+	}
+
+	return lists, nil
+}
+
+func (l *StaticDecisionLists) UpdateFromConfig(config *Config) error {
+	value, err := newStaticDecisionListsFromConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to update static decision lists from config: %w", err)
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	l.value = value
+
+	return nil
+}
+
+func (l *StaticDecisionLists) CheckPerSite(config *Config, site string, clientIp string) (Decision, bool) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	decision, ok := l.value.perSiteDecisionLists[site][clientIp]
+
+	// found as plain IP form, no need to check IPFilter
+	if ok {
+		return decision, true
+	}
+
+	// PerSiteDecisionListsIPFilter has different struct as PerSiteDecisionLists
+	// decision must iterate in order, once found in one of the list, break the loop
+	for _, iterateDecision := range []Decision{Allow, Challenge, NginxBlock, IptablesBlock} {
+		if instanceIPFilter, ok := l.value.perSiteDecisionListsIPFilter[site][iterateDecision]; ok && instanceIPFilter != nil {
+			if instanceIPFilter.Allowed(string(clientIp)) {
+				if config.Debug {
+					log.Printf("matched in per-site ipfilter %s %v %s", site, iterateDecision, clientIp)
+				}
+				return iterateDecision, true
+			}
+		}
+	}
+
+	return decision, false
+}
+
+func (l *StaticDecisionLists) CheckGlobal(config *Config, clientIp string) (Decision, bool) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	decision, ok := l.value.globalDecisionLists[clientIp]
+
+	if ok {
+		return decision, true
+	} else {
+		for _, iterateDecision := range []Decision{Allow, Challenge, NginxBlock, IptablesBlock} {
+			// check if Ipfilter ref associated to this iterateDecision exists
+			filter, ok := l.value.globalDecisionListsIPFilter[iterateDecision]
+			if ok && filter.Allowed(clientIp) {
+				if config.Debug {
+					log.Printf("matched in ipfilter %v %s", iterateDecision, clientIp)
+				}
+				return iterateDecision, true
+			}
+		}
+
+		return decision, false
+	}
+}
+
+func (l *StaticDecisionLists) CheckSitewideShaInv(site string) (FailAction, bool) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	failAction, ok := l.value.sitewideShaInvList[site]
+	return failAction, ok
+}
+
+func (l *StaticDecisionLists) CheckIsAllowed(site string, clientIp string) bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	// check per-site decision list first
+	decision, ok := l.value.perSiteDecisionLists[site][clientIp]
+	if ok && decision == Allow {
+		// log.Printf("checkIpInPerSiteDecisionList: matched %s %s", urlString, ipString)
+		return true
+	}
+
+	filter, ok := l.value.perSiteDecisionListsIPFilter[site][Allow]
+	if ok && filter.Allowed(clientIp) {
+		// log.Printf("checkIpInPerSiteDecisionList: matched in per-site ipfilter %s %s", urlString, ipString)
+		return true
+	}
+
+	// check global decision list
+	decision, ok = l.value.globalDecisionLists[clientIp]
+	if ok && decision == Allow {
+		// log.Printf("checkIpInGlobalDecisionList: matched %s", ipString)
+		return true
+	}
+
+	// not found with direct match, try to match if contain within CIDR subnet
+	filter, ok = l.value.globalDecisionListsIPFilter[Allow]
+	if ok && filter.Allowed(clientIp) {
+		// log.Printf("checkIpInGlobalDecisionList: matched in ipfilter %s", ipString)
+		return true
+	}
+
+	return false
+}
+
+type ipAddrToDecision map[string]Decision
+
+func (m ipAddrToDecision) String() string {
+	b := strings.Builder{}
+	for ip, decision := range m {
+		b.WriteString(fmt.Sprintf("%v", ip))
+		b.WriteString(":\n")
+		b.WriteString("\t")
+		b.WriteString(fmt.Sprintf("%v", decision.String()))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+type siteToIPAddrToDecision map[string]map[string]Decision
+
+func (m siteToIPAddrToDecision) String() string {
+	b := strings.Builder{}
+	for site, ipsToDecisions := range m {
+		b.WriteString(fmt.Sprintf("%v", site))
+		b.WriteString(":\n")
+		for ip, decision := range ipsToDecisions {
+			b.WriteString("\t")
+			b.WriteString(fmt.Sprintf("%v", ip))
+			b.WriteString(":\n")
+			b.WriteString("\t\t")
+			b.WriteString(fmt.Sprintf("%v", decision.String()))
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+type siteToFailAction 			map[string]FailAction
+type decisionToIPFilter     	map[Decision]*ipfilter.IPFilter
+type siteToDecisionToIPFilter 	map[string]map[Decision]*ipfilter.IPFilter
+
+// Decision lists that don't change unless the program is restarted or the config is hot-reloaded.
+type staticDecisionLists struct {
+	globalDecisionLists          ipAddrToDecision
+	perSiteDecisionLists         siteToIPAddrToDecision
+	sitewideShaInvList           siteToFailAction
+	globalDecisionListsIPFilter  decisionToIPFilter
+	perSiteDecisionListsIPFilter siteToDecisionToIPFilter
+}
+
+func newStaticDecisionLists() staticDecisionLists {
+	return staticDecisionLists{
+		globalDecisionLists:          make(ipAddrToDecision),
+		perSiteDecisionLists:         make(siteToIPAddrToDecision),
+		sitewideShaInvList:           make(siteToFailAction),
+		globalDecisionListsIPFilter:  make(decisionToIPFilter),
+		perSiteDecisionListsIPFilter: make(siteToDecisionToIPFilter),
+	}
+}
+
+func newStaticDecisionListsFromConfig(config *Config) (staticDecisionLists, error) {
+	out := newStaticDecisionLists()
+
+	for decisionString, ips := range config.GlobalDecisionLists {
+		decision, err := ParseDecision(decisionString)
+		if err != nil {
+			return staticDecisionLists{}, fmt.Errorf("failed to create static decision lists from config: %w", err)
+		}
+
+		for _, ip := range ips {
+			if !strings.Contains(ip, "/") {
+				out.globalDecisionLists[ip] = decision
+				if config.Debug {
+					log.Printf("global decision: %s, ip: %s\n", decisionString, ip)
+				}
+			} else {
+				if config.Debug {
+					log.Printf("global decision: %s, CIDR: %s, put in IPFilter\n", decisionString, ip)
+				}
+			}
+		}
+
+		out.globalDecisionListsIPFilter[decision] = ipfilter.New(ipfilter.Options{
+			AllowedIPs:     ips,
+			BlockByDefault: true,
+		})
+	}
+
+	for site, decisionToIps := range config.PerSiteDecisionLists {
+		for decisionString, ips := range decisionToIps {
+			decision, err := ParseDecision(decisionString)
+			if err != nil {
+				return staticDecisionLists{}, fmt.Errorf("failed to create static decision lists from config: %w", err)
+			}
+
+			for _, ip := range ips {
+				_, ok := out.perSiteDecisionLists[site]
+				if !ok {
+					out.perSiteDecisionLists[site] = make(ipAddrToDecision)
+					out.perSiteDecisionListsIPFilter[site] = make(decisionToIPFilter)
+				}
+				if !strings.Contains(ip, "/") {
+					out.perSiteDecisionLists[site][ip] = decision
+					if config.Debug {
+						log.Printf("site: %s, decision: %s, ip: %s\n", site, decisionString, ip)
+					}
+				} else {
+					if config.Debug {
+						log.Printf("per-site decision: %s, CIDR: %s, put in IPFilter\n", decisionString, ip)
+					}
+				}
+			}
+			if len(ips) > 0 {
+				// only init ipfilter if there is IP
+				// or there might be panic: assignment to entry in nil map
+				out.perSiteDecisionListsIPFilter[site][decision] = ipfilter.New(ipfilter.Options{
+					AllowedIPs:     ips,
+					BlockByDefault: true,
+				})
+			}
+		}
+	}
+
+	for site, failActionString := range config.SitewideShaInvList {
+		if config.Debug {
+			log.Printf("sitewide site: %s, failAction: %s\n", site, failActionString)
+		}
+
+		failAction, err := ParseFailAction(failActionString)
+		if err != nil {
+			return staticDecisionLists{}, err
+		}
+
+		out.sitewideShaInvList[site] = failAction
+	}
+
+	log.Printf("global decisions: %v\n", out.globalDecisionLists)
+	log.Printf("per-site decisions: %v\n", out.perSiteDecisionLists)
+
+	return out, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Decision lists that are updated frequently during the runtime of the program.
+type DynamicDecisionLists struct {
+	value dynamicDecisionLists
+	mutex sync.Mutex
+}
+
+func NewDynamicDecisionLists() *DynamicDecisionLists {
+	value := dynamicDecisionLists{
+		expiringDecisionLists:          make(ipAddrToExpiringDecision),
+		expiringDecisionListsSessionId: make(sessionIdToExpiringDecision),
+	}
+
+	return &DynamicDecisionLists{
+		value: value,
+		mutex: sync.Mutex{},
+	}
+}
+
+func (h *DynamicDecisionLists) Update(
+	config *Config,
+	ip string,
+	expires time.Time,
+	newDecision Decision,
+	fromBaskerville bool,
+	domain string,
+) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	existingExpiringDecision, ok := h.value.expiringDecisionLists[ip]
+	if ok {
+		if newDecision <= existingExpiringDecision.Decision {
+			if config.Debug {
+				log.Println("updateExpiringDecisionLists: not with less serious", existingExpiringDecision.Decision, newDecision, ip, domain)
+			}
+			return
+		}
+	}
+	if config.Debug {
+		log.Println("updateExpiringDecisionLists: update with existing and new: ", existingExpiringDecision.Decision, newDecision, ip, domain)
+		// log.Println("From baskerville", fromBaskerville)
+	}
+
+	// XXX We are not using nginx to banjax cache feature yet
+	// purgeNginxAuthCacheForIp(ip)
+
+	h.value.expiringDecisionLists[ip] = ExpiringDecision{
+		newDecision,
+		expires,
+		ip,
+		fromBaskerville,
+		domain,
+	}
+}
+
+func (h *DynamicDecisionLists) UpdateBySessionId(
+	config *Config,
+	ip string,
+	sessionId string,
+	expires time.Time,
+	newDecision Decision,
+	fromBaskerville bool,
+	domain string,
+) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	existingExpiringDecision, ok := h.value.expiringDecisionListsSessionId[sessionId]
+	if ok {
+		if newDecision <= existingExpiringDecision.Decision {
+			return
+		}
+	}
+
+	if config.Debug {
+		log.Printf("updateExpiringDecisionListsSessionId: Update session id decision with IP %s, session id %s, existing and new: %v, %v\n",
+			ip, sessionId, existingExpiringDecision.Decision, newDecision)
+	}
+
+	h.value.expiringDecisionListsSessionId[sessionId] = ExpiringDecision{
+		newDecision,
+		expires,
+		ip,
+		fromBaskerville,
+		domain,
+	}
+}
+
+func (h *DynamicDecisionLists) Check(sessionId string, clientIp string) (ExpiringDecision, bool) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	if sessionId != "" {
+		expiringDecision, ok := h.value.expiringDecisionListsSessionId[sessionId]
+		if ok {
+			log.Printf("DSC: found expiringDecision from session %s (%s)", sessionId, expiringDecision.Decision)
+			if time.Now().Sub(expiringDecision.Expires) > 0 {
+				delete(h.value.expiringDecisionListsSessionId, sessionId)
+				// log.Println("deleted expired decision from expiring lists")
+				ok = false
+			}
+			return expiringDecision, ok
+		}
+	}
+
+	expiringDecision, ok := h.value.expiringDecisionLists[clientIp]
+	if ok {
+		if time.Now().Sub(expiringDecision.Expires) > 0 {
+			delete(h.value.expiringDecisionLists, clientIp)
+			// log.Println("deleted expired decision from expiring lists")
+			ok = false
+		}
+	}
+	return expiringDecision, ok
+}
+
+func (h *DynamicDecisionLists) CheckByDomain(domain string) []BannedEntry {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	var bannedEntries []BannedEntry
+	for ip, expiringDecision := range h.value.expiringDecisionLists {
+		if expiringDecision.domain == domain && expiringDecision.Decision >= Challenge {
+			bannedEntries = append(bannedEntries, BannedEntry{
+				IpOrSessionId:   string(ip),
+				domain:          expiringDecision.domain,
+				Decision:        expiringDecision.Decision.String(), // Convert Decision to string
+				Expires:         expiringDecision.Expires,
+				FromBaskerville: expiringDecision.fromBaskerville,
+			})
+		}
+	}
+	for sessionId, expiringDecision := range h.value.expiringDecisionListsSessionId {
+		if expiringDecision.domain == domain && expiringDecision.Decision >= Challenge {
+			bannedEntries = append(bannedEntries, BannedEntry{
+				IpOrSessionId:   string(sessionId),
+				domain:          expiringDecision.domain,
+				Decision:        expiringDecision.Decision.String(), // Convert Decision to string
+				Expires:         expiringDecision.Expires,
+				FromBaskerville: expiringDecision.fromBaskerville,
+			})
+		}
+	}
+	return bannedEntries
+}
+
+func (h *DynamicDecisionLists) RemoveExpired() {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	for ip, expiringDecision := range h.value.expiringDecisionLists {
+		if time.Now().Sub(expiringDecision.Expires) > 0 {
+			delete(h.value.expiringDecisionLists, ip)
+			// log.Println("deleted expired decision from expiring lists")
+		}
+	}
+}
+
+func (h *DynamicDecisionLists) RemoveByIp(ip string) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	delete(h.value.expiringDecisionLists, ip)
+	// log.Printf("deleted IP %v from expiring lists", ip)
+}
+
+func (h *DynamicDecisionLists) Clear() {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	clear(h.value.expiringDecisionLists)
+	clear(h.value.expiringDecisionListsSessionId)
+}
+
+func (h *DynamicDecisionLists) Metrics() (lenExpiringChallenges int, lenExpiringBlocks int) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	lenExpiringChallenges = 0
+	lenExpiringBlocks = 0
+
+	for _, expiringDecision := range h.value.expiringDecisionLists {
+		if expiringDecision.Decision == Challenge {
+			lenExpiringChallenges += 1
+		} else if (expiringDecision.Decision == NginxBlock) || (expiringDecision.Decision == IptablesBlock) {
+			lenExpiringBlocks += 1
+		}
+	}
+
+	return
+}
+
+
+type ipAddrToExpiringDecision map[string]ExpiringDecision
+
+func (m ipAddrToExpiringDecision) String() string {
+	b := strings.Builder{}
+	for ip, expiringDecision := range m {
+		b.WriteString(fmt.Sprintf("%v", ip))
+		b.WriteString(":\n")
+		b.WriteString("\t")
+		b.WriteString(fmt.Sprintf("%v %v until %v (baskerville: %v)",
+			expiringDecision.domain,
+			expiringDecision.Decision.String(),
+			expiringDecision.Expires.Format("15:04:05"),
+			expiringDecision.fromBaskerville,
+		))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+type sessionIdToExpiringDecision map[string]ExpiringDecision
+
+// Decision lists that can update frequently during the runtime of the program. Updated from kafka
+// or the log tailer.
+type dynamicDecisionLists struct {
+	expiringDecisionLists          ipAddrToExpiringDecision
+	expiringDecisionListsSessionId sessionIdToExpiringDecision
+}
+
+func FormatDecisionLists(s *StaticDecisionLists, d *DynamicDecisionLists) string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	return fmt.Sprintf("per_site:\n%v\n\nglobal:\n%v\n\nexpiring:\n%v",
+		s.value.perSiteDecisionLists,
+		s.value.globalDecisionLists,
+		d.value.expiringDecisionLists,
+	)
+}

--- a/internal/decision.go
+++ b/internal/decision.go
@@ -234,9 +234,9 @@ func (m siteToIPAddrToDecision) String() string {
 	return b.String()
 }
 
-type siteToFailAction 			map[string]FailAction
-type decisionToIPFilter     	map[Decision]*ipfilter.IPFilter
-type siteToDecisionToIPFilter 	map[string]map[Decision]*ipfilter.IPFilter
+type siteToFailAction map[string]FailAction
+type decisionToIPFilter map[Decision]*ipfilter.IPFilter
+type siteToDecisionToIPFilter map[string]map[Decision]*ipfilter.IPFilter
 
 // Decision lists that don't change unless the program is restarted or the config is hot-reloaded.
 type staticDecisionLists struct {

--- a/internal/http_server.go
+++ b/internal/http_server.go
@@ -47,7 +47,7 @@ func RunHttpServer(
 	}
 
 	ginLogFile, _ := os.Create(ginLogFileName)
-	gin.DefaultWriter = io.MultiWriter(ginLogFile)
+	gin.DefaultWriter = ginLogFile
 
 	if !config.Debug {
 		gin.SetMode(gin.ReleaseMode)

--- a/internal/password_protected_path.go
+++ b/internal/password_protected_path.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2025, eQualit.ie inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package internal
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log"
+	"strings"
+	"sync/atomic"
+)
+
+type PasswordProtectedPaths struct {
+	content atomic.Pointer[content]
+}
+
+func NewPasswordProtectedPaths(config *Config) (*PasswordProtectedPaths, error) {
+	result := &PasswordProtectedPaths{
+		content: atomic.Pointer[content]{},
+	}
+
+	content, err := fromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	result.content.Store(content)
+
+	return result, nil
+}
+
+func (p *PasswordProtectedPaths) UpdateFromConfig(config *Config) error {
+	content, err := fromConfig(config)
+	if err != nil {
+		return err
+	}
+
+	p.content.Store(content)
+
+	return nil
+}
+
+func (p *PasswordProtectedPaths) GetPasswordHash(site string) ([]byte, bool) {
+	v, ok := p.content.Load().siteToPasswordHash[site]
+	return v, ok
+}
+
+func (p *PasswordProtectedPaths) GetRoamingPasswordHash(site string) ([]byte, bool) {
+	v, ok := p.content.Load().siteToRoamingPasswordHash[site]
+	return v, ok
+}
+
+func (p *PasswordProtectedPaths) GetExpandCookieDomain(site string) (bool, bool) {
+	v, ok := p.content.Load().siteToExpandCookieDomain[site]
+	return v, ok
+}
+
+func (p *PasswordProtectedPaths) IsException(site string, path string) bool {
+	content := p.content.Load()
+
+	exceptions, hasExceptions := content.siteToExceptionToBool[site]
+	if hasExceptions && exceptions[path] {
+		return true
+	} else {
+		return false
+	}
+}
+
+func (p *PasswordProtectedPaths) ClassifyPath(site string, path string) PathType {
+	content := p.content.Load()
+
+	pathToBools, ok := content.siteToPathToBool[site]
+	if ok {
+		exceptions, hasExceptions := content.siteToExceptionToBool[site]
+		if !hasExceptions || !exceptions[path] {
+			for protectedPath, boolFlag := range pathToBools {
+				if boolFlag && strings.HasPrefix(path, protectedPath) {
+					return PasswordProtected
+				}
+			}
+		} else {
+			return PasswordProtectedException
+		}
+	}
+
+	return NotPasswordProtected
+}
+
+type PathType int
+
+func (t PathType) String() string {
+	switch t {
+		case NotPasswordProtected: 		 return "NotPasswordProtected"
+		case PasswordProtected: 		 return "PasswordProtected"
+		case PasswordProtectedException: return "PasswordProtectedException"
+	}
+
+	panic("invalid PathType")
+}
+
+const (
+	NotPasswordProtected PathType = iota
+	PasswordProtected
+	PasswordProtectedException
+)
+
+type stringToBool map[string]bool
+type stringToStringToBool map[string]stringToBool
+type stringToBytes map[string][]byte
+
+type content struct {
+	siteToPathToBool          stringToStringToBool
+	siteToExceptionToBool     stringToStringToBool
+	siteToPasswordHash        stringToBytes
+	siteToRoamingPasswordHash stringToBytes
+	siteToExpandCookieDomain  stringToBool
+}
+
+func fromConfig(config *Config) (*content, error) {
+	siteToPathToBool := make(stringToStringToBool)
+	siteToExceptionToBool := make(stringToStringToBool)
+	siteToPasswordHash := make(stringToBytes)
+	siteToRoamingPasswordHash := make(stringToBytes)
+	siteToExpandCookieDomain := make(stringToBool)
+
+	for site, paths := range config.SitesToProtectedPaths {
+		for _, path := range paths {
+			path = "/" + strings.Trim(path, "/")
+			_, ok := siteToPathToBool[site]
+			if !ok {
+				siteToPathToBool[site] = make(stringToBool)
+			}
+			siteToPathToBool[site][path] = true
+			if config.Debug {
+				log.Printf("password protected path: %s/%s\n", site, path)
+			}
+		}
+	}
+
+	for site, exceptions := range config.SitesToProtectedPathExceptions {
+		for _, exception := range exceptions {
+			exception = "/" + strings.Trim(exception, "/")
+			_, ok := siteToExceptionToBool[site]
+			if !ok {
+				siteToExceptionToBool[site] = make(stringToBool)
+			}
+			siteToExceptionToBool[site][exception] = true
+		}
+	}
+
+	for site, passwordHashHex := range config.SitesToPasswordHashes {
+		passwordHashBytes, err := hex.DecodeString(passwordHashHex)
+		if err != nil {
+			return nil, fmt.Errorf("bad password hash: %w", err)
+		}
+		siteToPasswordHash[site] = passwordHashBytes
+		if config.Debug {
+			log.Println("passwordhashbytes:")
+			log.Println(passwordHashBytes)
+		}
+	}
+
+	for site, rootSiteToRoam := range config.SitesToPasswordHashesRoaming {
+		// try to get the password hash from the root site
+		passwordHashBytes, ok := siteToPasswordHash[rootSiteToRoam]
+		if ok {
+			siteToRoamingPasswordHash[site] = passwordHashBytes
+			siteToExpandCookieDomain[rootSiteToRoam] = true // set this to let root domain cookie expand to subdomains
+			// log.Printf("site %s has roaming password hash from root site %s\n", site, rootSiteToRoam)
+		}
+	}
+
+	content := &content{
+		siteToPathToBool,
+		siteToExceptionToBool,
+		siteToPasswordHash,
+		siteToRoamingPasswordHash,
+		siteToExpandCookieDomain,
+	}
+
+	return content, nil
+}

--- a/internal/rate_limit.go
+++ b/internal/rate_limit.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2025, eQualit.ie inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package internal
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// States for tracking rate limits triggered by matching regex rules or failed challenges.
+type RateLimitStates struct {
+	mutex                 sync.Mutex
+	regexStates           ipToRegexStates
+	failedChallengeStates ipToFailedChallengeStates
+}
+
+func NewRateLimitStates() *RateLimitStates {
+	return &RateLimitStates{
+		mutex:                 sync.Mutex{},
+		regexStates:           make(ipToRegexStates),
+		failedChallengeStates: make(ipToFailedChallengeStates),
+	}
+}
+
+func (s *RateLimitStates) String() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return fmt.Sprintf("regexes:\n%v\nfailed challenges:\n%v",
+		s.regexStates,
+		s.failedChallengeStates,
+	)
+}
+
+func (s *RateLimitStates) Metrics() (lenRegexStates int, lenFailedChallengeStates int) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	lenRegexStates = len(s.regexStates)
+	lenFailedChallengeStates = len(s.failedChallengeStates)
+
+	return
+}
+
+func (s *RateLimitStates) ApplyRegex(ip string, regexWithRate RegexWithRate, timestamp time.Time) (bool, RateLimitResult) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.regexStates.apply(ip, regexWithRate, timestamp)
+}
+
+// Returns a copy of the regex states for the given ip address.
+func (s *RateLimitStates) GetRegexStates(ip string) (RegexStates, bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if states, ok := s.regexStates[ip]; ok {
+		statesCopy := make(RegexStates)
+		for rule, state := range *states {
+			stateCopy := *state
+			statesCopy[rule] = &stateCopy
+		}
+
+		return statesCopy, true
+	} else {
+		return RegexStates{}, false
+	}
+}
+
+func (s *RateLimitStates) ApplyFailedChallenge(ip string, config *Config) RateLimitResult {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.failedChallengeStates.apply(ip, config)
+}
+
+type NumHitsAndIntervalStart struct {
+	NumHits           int
+	IntervalStartTime time.Time
+}
+
+type RateLimitResult struct {
+	MatchType RateLimitMatchType
+	Exceeded  bool
+}
+
+type RateLimitMatchType int
+
+const (
+	FirstTime RateLimitMatchType = iota
+	OutsideInterval
+	InsideInterval
+)
+
+func (t RateLimitMatchType) MarshalJSON() ([]byte, error) {
+	switch t {
+	case FirstTime:
+		return []byte("FirstTime"), nil
+	case OutsideInterval:
+		return []byte("OutsideInterval"), nil
+	case InsideInterval:
+		return []byte("InsideInterval"), nil
+	default:
+		return nil, fmt.Errorf("invalid RateLimitMatchType: %v", t)
+	}
+}
+
+type RegexStates map[string]*NumHitsAndIntervalStart
+
+type ipToRegexStates map[string]*RegexStates
+
+func (s ipToRegexStates) String() string {
+	buf := strings.Builder{}
+	for ip, states := range s {
+		buf.WriteString(fmt.Sprintf("%v", ip))
+		buf.WriteString(":\n")
+		for rule, state := range *states {
+			buf.WriteString("\t")
+			buf.WriteString(fmt.Sprintf("%v", rule))
+			buf.WriteString(":\n")
+			buf.WriteString("\t\t")
+			buf.WriteString(fmt.Sprintf("%v", *state))
+			buf.WriteString("\n")
+		}
+		buf.WriteString("\n")
+	}
+	return buf.String()
+}
+
+func (s *ipToRegexStates) apply(
+	ip string,
+	regexWithRate RegexWithRate,
+	timestamp time.Time,
+) (seenIp bool, result RateLimitResult) {
+	states, ok := (*s)[ip]
+	var state *NumHitsAndIntervalStart
+
+	if !ok {
+		seenIp = false
+		state = &NumHitsAndIntervalStart{1, timestamp}
+		(*s)[ip] = &RegexStates{regexWithRate.Rule: state}
+	} else {
+		seenIp = true
+		if ruleState, ok := (*states)[regexWithRate.Rule]; ok {
+			state = ruleState
+			if timestamp.Sub(state.IntervalStartTime) > regexWithRate.Interval {
+				result.MatchType = OutsideInterval
+				*state = NumHitsAndIntervalStart{1, timestamp}
+			} else {
+				result.MatchType = InsideInterval
+				state.NumHits++
+			}
+		} else {
+			result.MatchType = FirstTime
+			state = &NumHitsAndIntervalStart{1, timestamp}
+			(*states)[regexWithRate.Rule] = state
+		}
+	}
+
+	if state.NumHits > regexWithRate.HitsPerInterval {
+		state.NumHits = 0 // XXX should it be 1?...
+		result.Exceeded = true
+	} else {
+		result.Exceeded = false
+	}
+
+	return
+}
+
+type ipToFailedChallengeStates map[string]*NumHitsAndIntervalStart
+
+func (s ipToFailedChallengeStates) String() string {
+	buf := strings.Builder{}
+	for ip, state := range s {
+		buf.WriteString(
+			fmt.Sprintf(
+				"%v,: interval_start: %v, num hits: %v\n",
+				ip,
+				state.IntervalStartTime.Format("15:04:05"),
+				state.NumHits,
+			),
+		)
+	}
+	return buf.String()
+}
+
+func (s *ipToFailedChallengeStates) apply(ip string, config *Config) (result RateLimitResult) {
+	timestamp := time.Now()
+
+	state, ok := (*s)[ip]
+	if ok {
+		if timestamp.Sub(state.IntervalStartTime) > time.Duration(config.TooManyFailedChallengesIntervalSeconds) * time.Second {
+			// log.Println("IP has failed a challenge, but longer ago than $interval")
+			result.MatchType = OutsideInterval
+			*state = NumHitsAndIntervalStart{1, timestamp}
+		} else {
+			// log.Println("IP has failed a challenge in this $interval")
+			result.MatchType = InsideInterval
+			state.NumHits++
+		}
+	} else {
+		result.MatchType = FirstTime
+		state = &NumHitsAndIntervalStart{1, timestamp}
+		(*s)[ip] = state
+	}
+
+	if state.NumHits > config.TooManyFailedChallengesThreshold {
+		state.NumHits = 0 // XXX should it be 1?...
+		result.Exceeded = true
+	} else {
+		result.Exceeded = false
+	}
+
+	return
+}

--- a/internal/rate_limit.go
+++ b/internal/rate_limit.go
@@ -101,10 +101,9 @@ func (s *RegexRateLimitStates) String() string {
 	return s.states.String()
 }
 
-
 // States for tracking rate limits triggered by failed challenges.
 type FailedChallengeRateLimitStates struct {
-	mutex   sync.Mutex
+	mutex  sync.Mutex
 	states ipToFailedChallengeStates
 }
 
@@ -130,7 +129,7 @@ func (s *FailedChallengeRateLimitStates) Apply(ip string, config *Config) (resul
 
 	state, ok := s.states[ip]
 	if ok {
-		if timestamp.Sub(state.IntervalStartTime) > time.Duration(config.TooManyFailedChallengesIntervalSeconds) * time.Second {
+		if timestamp.Sub(state.IntervalStartTime) > time.Duration(config.TooManyFailedChallengesIntervalSeconds)*time.Second {
 			// log.Println("IP has failed a challenge, but longer ago than $interval")
 			result.MatchType = OutsideInterval
 			*state = NumHitsAndIntervalStart{1, timestamp}
@@ -231,4 +230,3 @@ func (s ipToFailedChallengeStates) String() string {
 	}
 	return buf.String()
 }
-

--- a/internal/rate_limit.go
+++ b/internal/rate_limit.go
@@ -13,54 +13,75 @@ import (
 	"time"
 )
 
-// States for tracking rate limits triggered by matching regex rules or failed challenges.
-type RateLimitStates struct {
-	mutex                 sync.Mutex
-	regexStates           ipToRegexStates
-	failedChallengeStates ipToFailedChallengeStates
+// States for tracking rate limits triggered by matching regex rules.
+type RegexRateLimitStates struct {
+	mutex  sync.Mutex
+	states ipToRegexStates
 }
 
-func NewRateLimitStates() *RateLimitStates {
-	return &RateLimitStates{
-		mutex:                 sync.Mutex{},
-		regexStates:           make(ipToRegexStates),
-		failedChallengeStates: make(ipToFailedChallengeStates),
+func NewRegexRateLimitStates() *RegexRateLimitStates {
+	return &RegexRateLimitStates{
+		mutex:  sync.Mutex{},
+		states: make(ipToRegexStates),
 	}
 }
 
-func (s *RateLimitStates) String() string {
+func (s *RegexRateLimitStates) Len() int {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	return fmt.Sprintf("regexes:\n%v\nfailed challenges:\n%v",
-		s.regexStates,
-		s.failedChallengeStates,
-	)
+	return len(s.states)
 }
 
-func (s *RateLimitStates) Metrics() (lenRegexStates int, lenFailedChallengeStates int) {
+func (s *RegexRateLimitStates) Apply(
+	ip string,
+	regexWithRate RegexWithRate,
+	timestamp time.Time,
+) (seenIp bool, result RateLimitResult) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	lenRegexStates = len(s.regexStates)
-	lenFailedChallengeStates = len(s.failedChallengeStates)
+	states, ok := s.states[ip]
+	var state *NumHitsAndIntervalStart
+
+	if !ok {
+		seenIp = false
+		state = &NumHitsAndIntervalStart{1, timestamp}
+		s.states[ip] = &RegexStates{regexWithRate.Rule: state}
+	} else {
+		seenIp = true
+		if ruleState, ok := (*states)[regexWithRate.Rule]; ok {
+			state = ruleState
+			if timestamp.Sub(state.IntervalStartTime) > regexWithRate.Interval {
+				result.MatchType = OutsideInterval
+				*state = NumHitsAndIntervalStart{1, timestamp}
+			} else {
+				result.MatchType = InsideInterval
+				state.NumHits++
+			}
+		} else {
+			result.MatchType = FirstTime
+			state = &NumHitsAndIntervalStart{1, timestamp}
+			(*states)[regexWithRate.Rule] = state
+		}
+	}
+
+	if state.NumHits > regexWithRate.HitsPerInterval {
+		state.NumHits = 0 // XXX should it be 1?...
+		result.Exceeded = true
+	} else {
+		result.Exceeded = false
+	}
 
 	return
 }
 
-func (s *RateLimitStates) ApplyRegex(ip string, regexWithRate RegexWithRate, timestamp time.Time) (bool, RateLimitResult) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	return s.regexStates.apply(ip, regexWithRate, timestamp)
-}
-
 // Returns a copy of the regex states for the given ip address.
-func (s *RateLimitStates) GetRegexStates(ip string) (RegexStates, bool) {
+func (s *RegexRateLimitStates) Get(ip string) (RegexStates, bool) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if states, ok := s.regexStates[ip]; ok {
+	if states, ok := s.states[ip]; ok {
 		statesCopy := make(RegexStates)
 		for rule, state := range *states {
 			stateCopy := *state
@@ -73,11 +94,72 @@ func (s *RateLimitStates) GetRegexStates(ip string) (RegexStates, bool) {
 	}
 }
 
-func (s *RateLimitStates) ApplyFailedChallenge(ip string, config *Config) RateLimitResult {
+func (s *RegexRateLimitStates) String() string {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	return s.failedChallengeStates.apply(ip, config)
+	return s.states.String()
+}
+
+
+// States for tracking rate limits triggered by failed challenges.
+type FailedChallengeRateLimitStates struct {
+	mutex   sync.Mutex
+	states ipToFailedChallengeStates
+}
+
+func NewFailedChallengeRateLimitStates() *FailedChallengeRateLimitStates {
+	return &FailedChallengeRateLimitStates{
+		mutex:  sync.Mutex{},
+		states: make(ipToFailedChallengeStates),
+	}
+}
+
+func (s *FailedChallengeRateLimitStates) Len() int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return len(s.states)
+}
+
+func (s *FailedChallengeRateLimitStates) Apply(ip string, config *Config) (result RateLimitResult) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	timestamp := time.Now()
+
+	state, ok := s.states[ip]
+	if ok {
+		if timestamp.Sub(state.IntervalStartTime) > time.Duration(config.TooManyFailedChallengesIntervalSeconds) * time.Second {
+			// log.Println("IP has failed a challenge, but longer ago than $interval")
+			result.MatchType = OutsideInterval
+			*state = NumHitsAndIntervalStart{1, timestamp}
+		} else {
+			// log.Println("IP has failed a challenge in this $interval")
+			result.MatchType = InsideInterval
+			state.NumHits++
+		}
+	} else {
+		result.MatchType = FirstTime
+		state = &NumHitsAndIntervalStart{1, timestamp}
+		s.states[ip] = state
+	}
+
+	if state.NumHits > config.TooManyFailedChallengesThreshold {
+		state.NumHits = 0 // XXX should it be 1?...
+		result.Exceeded = true
+	} else {
+		result.Exceeded = false
+	}
+
+	return
+}
+
+func (s *FailedChallengeRateLimitStates) String() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.states.String()
 }
 
 type NumHitsAndIntervalStart struct {
@@ -133,46 +215,6 @@ func (s ipToRegexStates) String() string {
 	return buf.String()
 }
 
-func (s *ipToRegexStates) apply(
-	ip string,
-	regexWithRate RegexWithRate,
-	timestamp time.Time,
-) (seenIp bool, result RateLimitResult) {
-	states, ok := (*s)[ip]
-	var state *NumHitsAndIntervalStart
-
-	if !ok {
-		seenIp = false
-		state = &NumHitsAndIntervalStart{1, timestamp}
-		(*s)[ip] = &RegexStates{regexWithRate.Rule: state}
-	} else {
-		seenIp = true
-		if ruleState, ok := (*states)[regexWithRate.Rule]; ok {
-			state = ruleState
-			if timestamp.Sub(state.IntervalStartTime) > regexWithRate.Interval {
-				result.MatchType = OutsideInterval
-				*state = NumHitsAndIntervalStart{1, timestamp}
-			} else {
-				result.MatchType = InsideInterval
-				state.NumHits++
-			}
-		} else {
-			result.MatchType = FirstTime
-			state = &NumHitsAndIntervalStart{1, timestamp}
-			(*states)[regexWithRate.Rule] = state
-		}
-	}
-
-	if state.NumHits > regexWithRate.HitsPerInterval {
-		state.NumHits = 0 // XXX should it be 1?...
-		result.Exceeded = true
-	} else {
-		result.Exceeded = false
-	}
-
-	return
-}
-
 type ipToFailedChallengeStates map[string]*NumHitsAndIntervalStart
 
 func (s ipToFailedChallengeStates) String() string {
@@ -190,32 +232,3 @@ func (s ipToFailedChallengeStates) String() string {
 	return buf.String()
 }
 
-func (s *ipToFailedChallengeStates) apply(ip string, config *Config) (result RateLimitResult) {
-	timestamp := time.Now()
-
-	state, ok := (*s)[ip]
-	if ok {
-		if timestamp.Sub(state.IntervalStartTime) > time.Duration(config.TooManyFailedChallengesIntervalSeconds) * time.Second {
-			// log.Println("IP has failed a challenge, but longer ago than $interval")
-			result.MatchType = OutsideInterval
-			*state = NumHitsAndIntervalStart{1, timestamp}
-		} else {
-			// log.Println("IP has failed a challenge in this $interval")
-			result.MatchType = InsideInterval
-			state.NumHits++
-		}
-	} else {
-		result.MatchType = FirstTime
-		state = &NumHitsAndIntervalStart{1, timestamp}
-		(*s)[ip] = state
-	}
-
-	if state.NumHits > config.TooManyFailedChallengesThreshold {
-		state.NumHits = 0 // XXX should it be 1?...
-		result.Exceeded = true
-	} else {
-		result.Exceeded = false
-	}
-
-	return
-}

--- a/internal/regex_rate_limiter.go
+++ b/internal/regex_rate_limiter.go
@@ -243,7 +243,7 @@ func applyRegexToLog(
 
 	ruleResult := RuleResult{}
 	ruleResult.RuleName = regex_with_rate.Rule
-	matched := regex_with_rate.CompiledRegex.Match([]byte(timeIpRest[2]))
+	matched := regex_with_rate.Regex.Match([]byte(timeIpRest[2]))
 	if !matched {
 		ruleResult.RegexMatch = false
 		// XXX maybe show the non-matches during debug logging?
@@ -291,10 +291,17 @@ func applyRegexToLog(
 	if (*(*ipToRegexStates)[ipString])[regex_with_rate.Rule].NumHits > regex_with_rate.HitsPerInterval {
 		// log.Println("!!! rate limit exceeded !!! ip: ", ipString)
 		ruleResult.RateLimitExceeded = true
-		decision, _ := ParseDecision(regex_with_rate.Decision) // XXX should be an enum already
-		banner.BanOrChallengeIp(config, ipString, decision, urlString)
+		banner.BanOrChallengeIp(config, ipString, regex_with_rate.Decision, urlString)
 		// log.Println(line.Text)
-		banner.LogRegexBan(config, timestamp, ipString, regex_with_rate.Rule, timeIpRest[2], decision)
+		banner.LogRegexBan(
+			config,
+			timestamp,
+			ipString,
+			regex_with_rate.Rule,
+			timeIpRest[2],
+			regex_with_rate.Decision,
+		)
+
 		(*(*ipToRegexStates)[ipString])[regex_with_rate.Rule].NumHits = 0 // XXX should it be 1?...
 	}
 

--- a/internal/regex_rate_limiter.go
+++ b/internal/regex_rate_limiter.go
@@ -20,7 +20,7 @@ import (
 
 func RunLogTailer(
 	ctx context.Context,
-	config *Config,
+	configHolder *ConfigHolder,
 	banner BannerInterface,
 	decisionLists *StaticDecisionLists,
 	rateLimitStates *RegexRateLimitStates,
@@ -28,7 +28,7 @@ func RunLogTailer(
 	var tailer *tail.Tail
 
 	for {
-		t, err := tail.TailFile(config.ServerLogFile, tail.Config{
+		t, err := tail.TailFile(configHolder.Get().ServerLogFile, tail.Config{
 			Follow: true,
 			Location: &tail.SeekInfo{
 				Offset: 0,
@@ -56,6 +56,7 @@ func RunLogTailer(
 		case <-ctx.Done():
 			return
 		case line := <-tailer.Lines:
+			config := configHolder.Get()
 			result := consumeLine(
 				line,
 				rateLimitStates,

--- a/internal/regex_rate_limiter.go
+++ b/internal/regex_rate_limiter.go
@@ -22,7 +22,7 @@ func RunLogTailer(
 	config *Config,
 	banner BannerInterface,
 	decisionLists *StaticDecisionLists,
-	rateLimitStates *RateLimitStates,
+	rateLimitStates *RegexRateLimitStates,
 	wg *sync.WaitGroup,
 ) {
 	// log.Println("len(RegexesWithRates) is: ", len(config.RegexesWithRates))
@@ -97,7 +97,7 @@ func parseTimestamp(timeIpRest []string) (timestamp time.Time, err error) {
 // parsing these unescaped space-separated strings is gross. maybe pass json instead.
 func consumeLine(
 	line *tail.Line,
-	rateLimitStates *RateLimitStates,
+	rateLimitStates *RegexRateLimitStates,
 	banner BannerInterface,
 	config *Config,
 	decisionLists *StaticDecisionLists,
@@ -202,7 +202,7 @@ func applyRegexToLog(
 	banner BannerInterface,
 	config *Config,
 	regexWithRate RegexWithRate,
-	rateLimitStates *RateLimitStates,
+	rateLimitStates *RegexRateLimitStates,
 	timeIpRest []string,
 	timestamp time.Time,
 	ipString string,
@@ -232,7 +232,7 @@ func applyRegexToLog(
 	}
 	result.SkipHost = false
 
-	seenIp, rateLimitResult := rateLimitStates.ApplyRegex(ipString, regexWithRate, timestamp)
+	seenIp, rateLimitResult := rateLimitStates.Apply(ipString, regexWithRate, timestamp)
 	result.SeenIp = seenIp
 	result.RateLimitResult = rateLimitResult
 

--- a/internal/regex_rate_limiter_test.go
+++ b/internal/regex_rate_limiter_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/hpcloud/tail"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 
 	// "io/ioutil"
 	"net/url"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -73,17 +73,6 @@ func (mb *MockBanner) IPSetDel(ip string) error {
 	return nil
 }
 
-var configToStructsMutex sync.Mutex
-
-func configToStructs(
-	config *Config,
-	passwordProtectedPaths *PasswordProtectedPaths,
-) {
-	configToStructsMutex.Lock()
-	defer configToStructsMutex.Unlock()
-
-	*passwordProtectedPaths = ConfigToPasswordProtectedPaths(config)
-}
 
 func TestConsumeLine(t *testing.T) {
 	configString := `
@@ -115,13 +104,8 @@ per_site_regexes_with_rates:
 	rateLimitStates := NewRegexRateLimitStates()
 	mockBanner := MockBanner{}
 
-	decisionLists, err := NewStaticDecisionListsFromConfig(&config)
-	if err != nil {
-		panic(fmt.Sprintf("couldn't create decision list: %v", err))
-	}
-
-	var passwordProtectedPaths PasswordProtectedPaths
-	configToStructs(&config, &passwordProtectedPaths)
+	decisionLists, err := NewStaticDecisionLists(&config)
+	assert.Nil(t, err)
 
 	nowNanos := float64(time.Now().UnixNano())
 	nowSeconds := nowNanos / 1e9
@@ -295,13 +279,8 @@ regexes_with_rates:
 	rateLimitStates := NewRegexRateLimitStates()
 	mockBanner := MockBanner{}
 
-	decisionLists, err := NewStaticDecisionListsFromConfig(&config)
-	if err != nil {
-		panic(fmt.Sprintf("couldn't create decision list: %v", err))
-	}
-
-	var passwordProtectedPaths PasswordProtectedPaths
-	configToStructs(&config, &passwordProtectedPaths)
+	decisionLists, err := NewStaticDecisionLists(&config)
+	assert.Nil(t, err)
 
 	nowNanos := float64(time.Now().UnixNano())
 	nowSeconds := nowNanos / 1e9
@@ -351,13 +330,8 @@ regexes_with_rates:
 		panic(fmt.Sprintf("couldn't parse config file: %v", err))
 	}
 
-	decisionLists, err := NewStaticDecisionListsFromConfig(&config)
-	if err != nil {
-		panic(fmt.Sprintf("couldn't create decision lists: %v", err))
-	}
-
-	var passwordProtectedPaths PasswordProtectedPaths
-	configToStructs(&config, &passwordProtectedPaths)
+	decisionLists, err := NewStaticDecisionLists(&config)
+	assert.Nil(t, err)
 
 	rateLimitStates := NewRegexRateLimitStates()
 	mockBanner := MockBanner{}

--- a/internal/regex_rate_limiter_test.go
+++ b/internal/regex_rate_limiter_test.go
@@ -112,7 +112,7 @@ per_site_regexes_with_rates:
 	if err != nil {
 		panic(fmt.Sprintf("couldn't parse config file: %v", err))
 	}
-	rateLimitStates := NewRateLimitStates()
+	rateLimitStates := NewRegexRateLimitStates()
 	mockBanner := MockBanner{}
 
 	decisionLists, err := NewStaticDecisionListsFromConfig(&config)
@@ -131,7 +131,7 @@ per_site_regexes_with_rates:
 	fmt.Println("-- 1 --")
 	consumeLine(&line, rateLimitStates, &mockBanner, &config, decisionLists)
 
-	ipStates, ok := rateLimitStates.GetRegexStates("1.2.3.4")
+	ipStates, ok := rateLimitStates.Get("1.2.3.4")
 	if !ok {
 		t.Fatalf("fail1")
 	}
@@ -153,7 +153,7 @@ per_site_regexes_with_rates:
 	fmt.Println("-- 2 --")
 	consumeLine(&line, rateLimitStates, &mockBanner, &config, decisionLists)
 
-	ipStates, ok = rateLimitStates.GetRegexStates("1.2.3.4")
+	ipStates, ok = rateLimitStates.Get("1.2.3.4")
 	if !ok {
 		t.Fatalf("fail4")
 	}
@@ -175,7 +175,7 @@ per_site_regexes_with_rates:
 	fmt.Println("-- 3 --")
 	consumeLine(&line, rateLimitStates, &mockBanner, &config, decisionLists)
 
-	ipStates, ok = rateLimitStates.GetRegexStates("1.2.3.4")
+	ipStates, ok = rateLimitStates.Get("1.2.3.4")
 	if !ok {
 		t.Fatalf("fail7")
 	}
@@ -197,7 +197,7 @@ per_site_regexes_with_rates:
 	fmt.Println("-- 4 --")
 	consumeLine(&line, rateLimitStates, &mockBanner, &config, decisionLists)
 
-	ipStates, ok = rateLimitStates.GetRegexStates("1.2.3.4")
+	ipStates, ok = rateLimitStates.Get("1.2.3.4")
 	if !ok {
 		t.Fatalf("fail10")
 	}
@@ -226,7 +226,7 @@ per_site_regexes_with_rates:
 	fmt.Println("-- 5 --")
 	consumeLine(&line, rateLimitStates, &mockBanner, &config, decisionLists)
 
-	ipStates, ok = rateLimitStates.GetRegexStates("1.2.3.4")
+	ipStates, ok = rateLimitStates.Get("1.2.3.4")
 	if !ok {
 		t.Fatalf("fail15")
 	}
@@ -257,7 +257,7 @@ per_site_regexes_with_rates:
 	consumeLine(&line, rateLimitStates, &mockBanner, &config, decisionLists)
 
 	// there should be a match for the per-site regex
-	ipStates, ok = rateLimitStates.GetRegexStates("1.6.6.6")
+	ipStates, ok = rateLimitStates.Get("1.6.6.6")
 	if !ok {
 		t.Fatalf("fail20")
 	}
@@ -269,7 +269,7 @@ per_site_regexes_with_rates:
 	consumeLine(&line, rateLimitStates, &mockBanner, &config, decisionLists)
 
 	// there should NO match for the per-site regex
-	ipStates, ok = rateLimitStates.GetRegexStates("1.6.6.7")
+	ipStates, ok = rateLimitStates.Get("1.6.6.7")
 	if ok {
 		t.Fatalf("fail21")
 	}
@@ -292,7 +292,7 @@ regexes_with_rates:
 	if err != nil {
 		panic(fmt.Sprintf("couldn't parse config file: %v", err))
 	}
-	rateLimitStates := NewRateLimitStates()
+	rateLimitStates := NewRegexRateLimitStates()
 	mockBanner := MockBanner{}
 
 	decisionLists, err := NewStaticDecisionListsFromConfig(&config)
@@ -311,7 +311,7 @@ regexes_with_rates:
 	fmt.Println("-- 1 --")
 	consumeLine(&line, rateLimitStates, &mockBanner, &config, decisionLists)
 
-	_, ok := rateLimitStates.GetRegexStates("1.2.3.4")
+	_, ok := rateLimitStates.Get("1.2.3.4")
 	if ok {
 		t.Fatalf("should not have found a state since we skip this host")
 	}
@@ -359,7 +359,7 @@ regexes_with_rates:
 	var passwordProtectedPaths PasswordProtectedPaths
 	configToStructs(&config, &passwordProtectedPaths)
 
-	rateLimitStates := NewRateLimitStates()
+	rateLimitStates := NewRegexRateLimitStates()
 	mockBanner := MockBanner{}
 
 	for j := 0; j < testCount; j++ {
@@ -373,7 +373,7 @@ regexes_with_rates:
 
 		consumeLine(&lineTail, rateLimitStates, &mockBanner, &config, decisionLists)
 
-		ipStates, ok := rateLimitStates.GetRegexStates(ip)
+		ipStates, ok := rateLimitStates.Get(ip)
 		if !ok {
 			t.Fatalf("fail1, IP not found in ipToRegexStates")
 		}


### PR DESCRIPTION
This PR encapsulates all shared state into structs that expose only thread-safe, deadlock-free API. This should fix all data races and potentially relieve some mutex contention due to more granular locking (and even lock-free design in some cases). Additionally this PR includes some refactoring and code cleanup.

